### PR TITLE
Feature/open file in tab

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,5 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add search field for git branches menu
 - Add checkout action on branch menu
 - Draw component on definition click
+- Add file tabs to wrap monaco editor on text view
 
 [unreleased]: https://github.com/ditrit/leto-modelizer/blob/main/changelog.md#unreleased

--- a/cypress/e2e/file/file_explorer.feature
+++ b/cypress/e2e/file/file_explorer.feature
@@ -1,0 +1,137 @@
+Feature: Test file explorer and file tabs
+
+  Background:
+    Given I clear cache
+    And I set viewport size to "1536" px for width and "960" px for height
+    And I visit the "/"
+
+    When I click on "[data-cy=\"create-empty-project\"]"
+    Then I expect current url is "/modelizer/project-[a-f0-9]{8}/model"
+    And  I extract "project-[a-f0-9]{8}" from url in field "projectName" of context
+    And  I visit the "/#/modelizer/{{projectName}}/text"
+
+    When I click on "[data-cy=\"project-settings\"]"
+    And  I click on "[data-cy=\"git-settings-menu\"]"
+    And  I set on "[data-cy=\"git-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I set on "[data-cy=\"git-form\"] [data-cy=\"git-username-input\"]" text "test"
+    And  I set on "[data-cy=\"git-form\"] [data-cy=\"git-token-input\"]" text "test"
+    And  I click on "[data-cy=\"git-form\"] [data-cy=\"git-form-submit\"]"
+    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    And  I expect "[data-cy=\"git-form\"]" is closed
+    And  I expect "[data-cy=\"git-current-branch\"] " is "master"
+
+    When I click on "[data-cy=\"git-current-branch\"]"
+    And  I click on "[data-cy=\"git-menu-branch-remote-test/remote\"]"
+    And  I click on "[data-cy=\"git-menu-branch-checkout-test/remote\"]"
+    And  I expect "[data-cy=\"git-current-branch\"]" is "test/remote"
+    And  I click on body to close popup
+    Then I expect "[data-cy=\"file-explorer\"]" exists
+
+  Scenario: Double click on a file should open a tab
+    When I double click on "[data-cy=\"file-explorer-README.md\"]"
+    Then I expect "[data-cy=\"file-tabs\"]" exists
+    And  I expect "[data-cy=\"monaco-editor\"]" exists
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tab-label-README.md\"]" is "README.md"
+
+  Scenario: Open a file and click to close the active tab should display nothing on the file tabs
+    When I double click on "[data-cy=\"file-explorer-README.md\"]"
+    Then I expect "[data-cy=\"file-tabs\"]" exists
+    And  I expect "[data-cy=\"monaco-editor\"]" exists
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+
+    When I click on "[data-cy=\"active-tab\"] [data-cy=\"close-file-tab\"]"
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 0 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" not exists
+    And  I expect "[data-cy=\"monaco-editor\"]" not exists
+
+  Scenario: Open two files then click on the inactive file and tab should switch the active tab
+    When I double click on "[data-cy=\"file-explorer-README.md\"]"
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
+
+    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 2 times on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tab-label-branch.txt\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+
+    When I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]"
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 2 times on screen
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" not exists
+
+  Scenario: Open two files and click to close the active tab, the other opened tab becomes the active tab
+    When I double click on "[data-cy=\"file-explorer-README.md\"]"
+    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 2 times on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tab-label-branch.txt\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+
+    When I click on "[data-cy=\"active-tab\"] [data-cy=\"close-file-tab\"]"
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tab-label-README.md\"]" is "README.md"
+    Then I expect "[data-cy=\"file-tab-label-branch.txt\"]" not exists
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" not exists
+
+  Scenario: Open a file and checkout branch, the file should reload if its content has changed
+    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+
+    When I click on "[data-cy=\"git-current-branch\"]"
+    And  I click on "[data-cy=\"git-menu-branch-remote-main\"]"
+    And  I click on "[data-cy=\"git-menu-branch-checkout-main\"]"
+    And  I expect "[data-cy=\"git-current-branch\"]" is "main"
+    And  I click on body to close popup
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
+
+  Scenario: Open two files, checkout branch and if an opened file no longer exists, its corresponding tab should be closed
+    When I double click on "[data-cy=\"file-explorer-README.md\"]"
+    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 2 times on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+
+    When I click on "[data-cy=\"git-current-branch\"]"
+    And  I click on "[data-cy=\"git-menu-branch-remote-main\"]"
+    And  I click on "[data-cy=\"git-menu-branch-checkout-main\"]"
+    And  I expect "[data-cy=\"git-current-branch\"]" is "main"
+    And  I click on body to close popup
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
+
+  Scenario: Open two files and checkout branch, then the active tab is closed, the other opened tab becomes the active tab
+    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    Then I double click on "[data-cy=\"file-explorer-README.md\"]"
+    And  I expect "[data-cy=\"file-tabs-container\"]" appear 2 times on screen
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
+
+    When I click on "[data-cy=\"git-current-branch\"]"
+    And  I click on "[data-cy=\"git-menu-branch-remote-main\"]"
+    And  I click on "[data-cy=\"git-menu-branch-checkout-main\"]"
+    And  I expect "[data-cy=\"git-current-branch\"]" is "main"
+    And  I click on body to close popup
+    Then I expect "[data-cy=\"file-tabs-container\"]" appear 1 time on screen
+    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
+

--- a/cypress/e2e/modelizerpage.feature
+++ b/cypress/e2e/modelizerpage.feature
@@ -22,18 +22,20 @@ Feature: Test modelizer page
     When I visit the "/#/modelizer/{{projectName}}/text"
     Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
     And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"monaco-editor\"]" exists
+    And  I expect "[data-cy=\"file-explorer\"]" exists
+    And  I expect "[data-cy=\"file-tabs\"]" exists
 
   Scenario: Clicking on switch should change page content
     When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
     Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
     And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"monaco-editor\"]" exists
-    And I expect current url is "/{{projectName}}/text"
+    And  I expect "[data-cy=\"file-explorer\"]" exists
+    And  I expect "[data-cy=\"file-tabs\"]" exists
+    And  I expect current url is "/{{projectName}}/text"
 
     When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
     And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And I expect current url is "/{{projectName}}/model"
+    And  I expect current url is "/{{projectName}}/model"
 
   Scenario: Clicking on application logo should redirect to homepage
     When I click on "[data-cy=\"app-logo-link\"]"
@@ -41,4 +43,3 @@ Feature: Test modelizer page
 
   Scenario: The modelizer page should have the components definitions drawer
     Then I expect '[data-cy="components-definitions-drawer"]' exists
-

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -11,7 +11,8 @@ Feature: Test roundtrip of the application
     When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
     Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
     And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"monaco-editor\"]" exists
+    And  I expect "[data-cy=\"file-explorer\"]" exists
+    And  I expect "[data-cy=\"file-tabs\"]" exists
     And I expect current url is "/#/modelizer/{{ projectName }}/text"
 
     When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"

--- a/cypress/support/step_definitions/event.js
+++ b/cypress/support/step_definitions/event.js
@@ -5,3 +5,12 @@ When('I click on {string}', (templateSelector) => {
   const selector = nunjucks.renderString(templateSelector, cy.context);
   cy.get(selector).click();
 });
+
+When('I double click on {string}', (templateSelector) => {
+  const selector = nunjucks.renderString(templateSelector, cy.context);
+  cy.get(selector).dblclick();
+});
+
+When('I click on body to close popup', () => {
+  cy.get('body').click(0, 0);
+});

--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -8,15 +8,20 @@
     data-cy="file-explorer"
   >
     <template #default-header="{expanded, node}">
-      <div class="tree-node">
+      <div
+        :class="['tree-node-container tree-node items-center',
+          {'selected-node' : selectedFileId === node.id && !node.isFolder}]"
+        @dblclick="onNodeClicked(node)"
+        :data-cy="`file-explorer-${node.label}`"
+      >
         <q-icon
-          color="primary"
-          :name="`${node.icon}${expanded ? '-open' : ''}`"
           class="q-mx-sm"
+          color="primary"
+          size="xs"
+          :name="`${node.icon}${expanded ? '-open' : ''}`"
         />
         <span
-          @click="selected = node.id"
-          :class="{ 'text-bold' : selected === node.id}"
+          :class="['tree-node', { 'text-bold' : selectedFileId === node.id}]"
         >
           {{node.label}}
         </span>
@@ -26,15 +31,53 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import FileEvent from 'src/composables/events/FileEvent';
+import { ref, onMounted, onUnmounted } from 'vue';
+import { readProjectFile } from 'src/composables/Project';
 
-const selected = ref('');
-
-defineProps({
+const props = defineProps({
   nodes: {
     type: Array,
     required: true,
   },
+  projectName: {
+    type: String,
+    required: true,
+  },
+});
+
+const selectedFileId = ref('');
+let fileEventSubscription;
+
+/**
+ * Set selectedFileId equal to fileId param.
+ */
+function setSelectedFileId(fileId) {
+  selectedFileId.value = fileId;
+}
+
+/**
+ * If node clicked from Tree is a file, set selectedFileId as its id,
+ * read file to get its content and pass it to OpenFileEvent
+ *
+ * @param {Object} node - Tree node
+ * Example { icon: "fa-regular fa-file", id: "terraform/app.tf", isFolder: false, label: "app.tf" }
+ */
+function onNodeClicked(node) {
+  if (node.isFolder) return;
+  setSelectedFileId(node.id);
+  readProjectFile(props.projectName, { path: node.id })
+    .then(({ content }) => {
+      FileEvent.OpenFileEvent.next({ id: node.id, label: node.label, content });
+    });
+}
+
+onMounted(() => {
+  fileEventSubscription = FileEvent.SelectFileEvent.subscribe(setSelectedFileId);
+});
+
+onUnmounted(() => {
+  fileEventSubscription.unsubscribe();
 });
 
 </script>
@@ -42,5 +85,21 @@ defineProps({
 <style lang="scss" scoped>
 .tree-node:hover {
   cursor: pointer;
+}
+.tree-node {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}
+.tree-node-container {
+  width: 100%;
+  display: inline-flex
+}
+.selected-node {
+  background: rgba($primary, 0.2);
+  border-radius: 4px
 }
 </style>

--- a/src/components/ModelizerTextView.vue
+++ b/src/components/ModelizerTextView.vue
@@ -1,16 +1,31 @@
 <template>
-  <div class="modelizer-text-view row"
+  <div
+    class="modelizer-text-view row"
     data-cy="modelizer-text-view"
   >
-    <div>
+    <div class="col-2 bg-grey-2 file-explorer-container">
       <git-branch-card/>
       <file-explorer
-          class="q-ma-md col-2 overflow-auto"
-          :nodes="nodes"
+        class="q-pa-md overflow-auto"
+        :nodes="nodes"
+        :project-name="projectName"
       />
     </div>
-    <q-separator vertical inset />
-    <monaco-editor :viewType="viewType" class="col-auto" />
+
+    <q-separator vertical />
+
+    <file-tabs
+      :files="files"
+      v-model="activeFileId"
+      @update:close-file="closeFile"
+    >
+      <template v-slot="{ file }">
+        <monaco-editor
+          :content="file.content"
+          :viewType="viewType"
+        />
+      </template>
+    </file-tabs>
   </div>
 </template>
 
@@ -19,24 +34,129 @@ import { getTree } from 'src/composables/FileExplorer';
 import MonacoEditor from 'components/editor/MonacoEditor.vue';
 import FileExplorer from 'components/FileExplorer.vue';
 import GitBranchCard from 'components/card/GitBranchCard';
+import FileTabs from 'components/tab/FileTabs.vue';
+import {
+  onMounted,
+  onUnmounted,
+  ref,
+  watch,
+} from 'vue';
+import { getProjectFiles, readProjectFile } from 'src/composables/Project';
+import FileEvent from 'src/composables/events/FileEvent';
+import GitEvent from 'src/composables/events/GitEvent';
 
-defineProps({
-  viewType: String,
+const props = defineProps({
+  viewType: {
+    type: String,
+    default: 'model',
+  },
+  projectName: {
+    type: String,
+    required: true,
+  },
 });
 
-// TODO : Remove Hard-coded data when link with git provider will be done
-const fileInformation = [
-  { path: '.gitignore' },
-  { path: '/home/terraform/app.tf' },
-  { path: '/home/terraform/user.tf' },
-  { path: '/tests/example.spec.js' },
-  { path: '/tests/unit/file3.tf' },
-  { path: '/tests/unit/events.spec.js' },
-  { path: 'README.md' },
-  { path: '/home/file1.tf' },
-  { path: '/home/file2.tf' },
-];
+const files = ref([]);
+const activeFileId = ref('');
+const nodes = ref([]);
 
-const nodes = getTree(fileInformation);
+let fileEventSubscription;
+let updateRemoteSubscription;
+let checkoutSubscription;
+
+/**
+ * Update files array when a new file is open
+ *
+ * @param {Object} file
+ * Example: { id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' },
+ */
+function onOpenFileEvent(file) {
+  activeFileId.value = file.id;
+  const existingFile = files.value.find(({ id }) => id === file.id);
+  if (!existingFile) {
+    files.value.push(file);
+  }
+}
+
+/**
+ * Update active file id by setting the value equal to the last element of files,
+ * otherwise null if files is empty.
+ */
+function updateActiveFileId() {
+  if (files.value.length) {
+    activeFileId.value = files.value[files.value.length - 1].id;
+    FileEvent.SelectFileEvent.next(activeFileId.value);
+  } else {
+    activeFileId.value = '';
+    FileEvent.SelectFileEvent.next('');
+  }
+}
+
+/**
+ * Close file by removing it from files array using its id.
+ * If the closed file was the current active file, update activeFileId.
+ *
+ * @param {string} fileId - id of closed file
+ */
+function closeFile(fileId) {
+  const index = files.value.findIndex((file) => file.id === fileId);
+  if (index !== -1) {
+    files.value.splice(index, 1);
+  }
+  if (fileId === activeFileId.value) {
+    updateActiveFileId();
+  }
+}
+
+/**
+ * Update project nodes and files.
+ * If the previous active file is not contained in files, update activeFileId.
+ */
+function updateProjectFiles() {
+  getProjectFiles(props.projectName)
+    .then((fileInformations) => {
+      nodes.value = getTree(fileInformations);
+      const projectFilesIds = fileInformations.map((file) => file.path);
+      files.value = files.value.filter(({ id }) => projectFilesIds.includes(id));
+      files.value.forEach((file) => {
+        readProjectFile(props.projectName, { path: file.id })
+          .then(({ content }) => {
+            file.content = content;
+          });
+      });
+      const isActiveFileInFiles = files.value.find(({ id }) => id === activeFileId.value);
+      if (!isActiveFileInFiles) {
+        updateActiveFileId();
+      }
+    });
+}
+
+watch(activeFileId, () => {
+  FileEvent.SelectFileEvent.next(activeFileId.value);
+});
+
+onMounted(() => {
+  updateProjectFiles();
+  fileEventSubscription = FileEvent.OpenFileEvent.subscribe(onOpenFileEvent);
+  updateRemoteSubscription = GitEvent.UpdateRemoteEvent.subscribe(updateProjectFiles);
+  checkoutSubscription = GitEvent.CheckoutEvent.subscribe(updateProjectFiles);
+});
+
+onUnmounted(() => {
+  fileEventSubscription.unsubscribe();
+  updateRemoteSubscription.unsubscribe();
+  checkoutSubscription.unsubscribe();
+});
 
 </script>
+
+<style lang="scss" scoped>
+.modelizer-text-view {
+ // set min-height to full height excluding header height
+ // 74px = height of header
+  min-height: calc(100vh - 74px)
+}
+.file-explorer-container {
+  min-width: 200px;
+}
+</style>

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -12,13 +12,21 @@ import {
   onUpdated,
   nextTick,
   ref,
+  watch,
 } from 'vue';
 
 const monaco = require('monaco-editor');
 
 // Need to be here, otherwise OnUpdated is not called.
-defineProps({
-  viewType: String,
+const props = defineProps({
+  viewType: {
+    type: String,
+    default: 'text',
+  },
+  content: {
+    type: String,
+    default: '',
+  },
 });
 
 const container = ref(null);
@@ -29,7 +37,7 @@ let editor;
  */
 function createEditor() {
   editor = monaco.editor.create(container.value, {
-    value: '',
+    value: props.content,
     language: 'text',
   });
 }
@@ -45,6 +53,10 @@ function updateEditorLayout() {
     width: container.value.offsetWidth,
   });
 }
+
+watch(() => props.content, () => {
+  editor.setValue(props.content);
+});
 
 onMounted(() => {
   nextTick(createEditor);

--- a/src/components/tab/FileTabs.vue
+++ b/src/components/tab/FileTabs.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="col" data-cy="file-tabs">
+    <q-tabs
+      v-model="internalActiveFile"
+      dense
+      class="text-grey bg-grey-2 tab-container"
+      active-color="primary"
+      indicator-color="transparent"
+      align="left"
+    >
+      <q-tab
+        v-for="file in files"
+        :key="file.id"
+        :name="file.id"
+        no-caps
+        :ripple="false"
+        :class="`tab-item
+          ${internalActiveFile === file.id ? 'tab-item--active' : 'tab-item--inactive'}`"
+        data-cy="file-tabs-container"
+      >
+        <div
+          class="row items-center"
+          :data-cy="`${internalActiveFile === file.id ? 'active' : 'inactive'}-tab`"
+        >
+          <span
+            :class="internalActiveFile === file.id ? 'text-bold' : ''"
+            :data-cy="`file-tab-label-${file.label}`"
+          >
+            {{file.label}}
+          </span>
+          <q-btn
+            flat
+            round
+            size="xs"
+            :color="internalActiveFile === file.id ? 'primary' : 'gray'"
+            icon="fa-solid fa-xmark"
+            class="q-ml-sm"
+            @click.stop="emit('update:close-file', file.id)"
+            data-cy="close-file-tab"
+          />
+        </div>
+      </q-tab>
+    </q-tabs>
+    <q-tab-panels v-model="internalActiveFile">
+      <q-tab-panel
+        v-for="file in files"
+        :key="file.id"
+        :name="file.id"
+        :data-cy="`file-tab-content-${file.label}`"
+      >
+        <slot :file="file"></slot>
+      </q-tab-panel>
+    </q-tab-panels>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+
+const emit = defineEmits(['update:modelValue', 'update:close-file']);
+
+const props = defineProps({
+  files: {
+    type: Array,
+    required: true,
+  },
+  modelValue: {
+    type: String,
+    required: true,
+  },
+});
+
+const internalActiveFile = ref('');
+
+watch(internalActiveFile, () => {
+  if (internalActiveFile.value !== props.modelValue) {
+    emit('update:modelValue', internalActiveFile.value);
+  }
+});
+
+watch(() => props.modelValue, (newModelValue) => {
+  internalActiveFile.value = newModelValue;
+});
+
+</script>
+
+<style lang="scss" scoped>
+  .tab-container {
+    box-shadow: inset 0 -1px 0 #eee
+  }
+  .tab-item {
+    border-right: solid 1px #eee
+  }
+  .tab-item--active {
+    background: white;
+    box-shadow: inset 0 -1px 0 white;
+  }
+  .tab-item--inactive {
+    background: #eee
+  }
+</style>

--- a/src/composables/Project.js
+++ b/src/composables/Project.js
@@ -118,30 +118,6 @@ export async function getProjectFiles(projectId) {
 }
 
 /**
- * Get file content.
- * @param {String} projectId - Id of project.
- * @param {FileInformation} fileInformation - Object that contain file path.
- * @return {Promise<FileInput>} Promise with file content on success otherwise error.
- */
-export async function readProjectFile(projectId, fileInformation) {
-  const project = getProjectById(projectId);
-  const dir = `/${project.id}`;
-
-  const commitOid = await git.resolveRef({ fs, dir });
-  const { blob } = git.readBlob({
-    fs,
-    dir,
-    oid: commitOid,
-    filepath: fileInformation.path,
-  });
-
-  return new FileInput({
-    path: fileInformation.path,
-    content: Buffer.from(blob).toString('utf8'),
-  });
-}
-
-/**
  * Get current branch of git project.
  * @param {String} projectId - Id of project.
  * @return {Promise<String>} Promise with current branch name on success otherwise error.
@@ -154,6 +130,29 @@ export async function getCurrentBranch(projectId) {
   });
 }
 
+/**
+ * Get file content.
+ * @param {String} projectId - Id of project.
+ * @param {FileInformation} fileInformation - Object that contain file path.
+ * @return {Promise<FileInput>} Promise with file content on success otherwise error.
+ */
+export async function readProjectFile(projectId, fileInformation) {
+  const currentBranch = await getCurrentBranch(projectId);
+  const dir = `/${projectId}`;
+
+  const commitOid = await git.resolveRef({ fs, dir, ref: currentBranch });
+  const { blob } = await git.readBlob({
+    fs,
+    dir,
+    oid: commitOid,
+    filepath: fileInformation.path,
+  });
+
+  return new FileInput({
+    path: fileInformation.path,
+    content: Buffer.from(blob).toString('utf8'),
+  });
+}
 /**
  * Get all branches of project.
  * @param {String} projectId - Id of project.

--- a/src/composables/events/FileEvent.js
+++ b/src/composables/events/FileEvent.js
@@ -1,0 +1,23 @@
+import { Subject } from 'rxjs';
+
+/**
+ * Represent a rxjs Event object to emit and to receive events about file opening.
+ * The event should be an Object that contains the `id` (path), the `label`
+ * and the `content` of the file.
+ * Example: { id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' },
+ * @typedef {Subject} OpenFileEvent
+ */
+const OpenFileEvent = new Subject();
+
+/**
+ * Represent a rxjs Event object to emit and to receive events about file selecting.
+ * The event should be the selected file's id.
+ * Example: 'terraform/app.tf' or '' when no file is selected.
+ * @typedef {Subject} SelectFileEvent
+ */
+const SelectFileEvent = new Subject();
+
+export default {
+  OpenFileEvent,
+  SelectFileEvent,
+};

--- a/src/pages/ModelizerPage.vue
+++ b/src/pages/ModelizerPage.vue
@@ -14,7 +14,11 @@
         data-cy="modelizer-page"
       >
         <modelizer-model-view v-show="viewType === 'model'" />
-        <modelizer-text-view v-show="viewType === 'text'" :viewType="viewType" />
+        <modelizer-text-view
+          v-show="viewType === 'text'"
+          :viewType="viewType"
+          :project-name="projectName"
+        />
         <git-configuration-dialog :project-name="projectName"/>
       </q-page>
     </q-page-container>

--- a/tests/unit/components/FileExplorer.spec.js
+++ b/tests/unit/components/FileExplorer.spec.js
@@ -1,0 +1,134 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import i18nConfiguration from 'src/i18n';
+import FileExplorer from 'src/components/FileExplorer.vue';
+import FileEvent from 'src/composables/events/FileEvent';
+
+installQuasarPlugin();
+
+jest.mock('src/composables/Project', () => ({
+  readProjectFile: jest.fn().mockResolvedValue([{ path: 'terraform/app.tf', content: 'Hello World' }]),
+}));
+
+jest.mock('src/composables/events/FileEvent', () => ({
+  OpenFileEvent: {
+    next: jest.fn(),
+  },
+  SelectFileEvent: {
+    subscribe: jest.fn(),
+  },
+}));
+
+describe('Test component: FileExplorer', () => {
+  let wrapper;
+  let subscribe;
+  let unsubscribe;
+
+  const emit = jest.fn();
+
+  FileEvent.OpenFileEvent.next.mockImplementation(() => emit());
+
+  FileEvent.SelectFileEvent.subscribe.mockImplementation(() => {
+    subscribe();
+    return { unsubscribe };
+  });
+
+  beforeEach(() => {
+    subscribe = jest.fn();
+    unsubscribe = jest.fn();
+
+    wrapper = shallowMount(FileExplorer, {
+      global: {
+        plugins: [
+          createI18n({
+            locale: 'en-US',
+            messages: i18nConfiguration,
+          }),
+        ],
+      },
+      props: {
+        nodes: [{
+          id: 'terraform',
+          icon: 'fa-solid fa-folder',
+          label: 'terraform',
+          children: [{
+            id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+          }],
+          isFolder: true,
+        }],
+        projectName: 'project-00000000',
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: nodes', () => {
+      it('should match nodes', () => {
+        const nodes = [{
+          id: 'terraform',
+          icon: 'fa-solid fa-folder',
+          label: 'terraform',
+          children: [{
+            id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+          }],
+          isFolder: true,
+        }];
+        expect(wrapper.vm.props.nodes).toEqual(nodes);
+      });
+    });
+
+    describe('Test props: projectName', () => {
+      it('should match "project-00000000"', () => {
+        expect(wrapper.vm.props.projectName).toEqual('project-00000000');
+      });
+    });
+  });
+
+  describe('Test function: setSelectedFileId', () => {
+    it('should assign the value of selectedFileId equal to the parameter', () => {
+      wrapper.vm.setSelectedFileId('terraform/app.tf');
+      expect(wrapper.vm.selectedFileId).toEqual('terraform/app.tf');
+    });
+  });
+
+  describe('Test function: onNodeClicked', () => {
+    it('should not emit when node.isFolder is true', async () => {
+      expect(emit).not.toHaveBeenCalled();
+      const node = {
+        id: 'terraform',
+        icon: 'fa-solid fa-folder',
+        label: 'terraform',
+        children: [{
+          id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+        }],
+        isFolder: true,
+      };
+      await wrapper.vm.onNodeClicked(node);
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit when node.isFolder is false', async () => {
+      expect(emit).not.toHaveBeenCalled();
+      const node = {
+        id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+      };
+      await wrapper.vm.onNodeClicked(node);
+      expect(emit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onMounted', () => {
+    it('should subscribe to SelectFileEvent', () => {
+      expect(subscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onUnmounted', () => {
+    it('should unsubscribe to SelectFileEvent', () => {
+      expect(unsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/components/ModelizerTextView.spec.js
+++ b/tests/unit/components/ModelizerTextView.spec.js
@@ -1,30 +1,289 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import ModelizerTextView from 'src/components/ModelizerTextView.vue';
+import FileEvent from 'src/composables/events/FileEvent';
+import GitEvent from 'src/composables/events/GitEvent';
 
 installQuasarPlugin();
 
-jest.mock('components/card/GitBranchCard', () => {});
+jest.mock('src/composables/Project', () => ({
+  getProjectFiles: jest.fn(() => Promise.resolve([{ path: 'terraform/app.tf' }])),
+  readProjectFile: jest.fn(() => Promise.resolve({ path: 'terraform/app.tf', content: 'new content' })),
+}));
+
+jest.mock('src/composables/FileExplorer', () => ({
+  getTree: jest.fn(() => ([
+    {
+      id: 'terraform',
+      icon: 'fa-solid fa-folder',
+      label: 'terraform',
+      children: [{
+        id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+      }],
+      isFolder: true,
+    }]
+  )),
+}));
+
+jest.mock('src/composables/events/FileEvent', () => ({
+  OpenFileEvent: {
+    subscribe: jest.fn(),
+  },
+  SelectFileEvent: {
+    next: jest.fn(),
+  },
+}));
+
+jest.mock('src/composables/events/GitEvent', () => ({
+  UpdateRemoteEvent: {
+    subscribe: jest.fn(),
+  },
+  CheckoutEvent: {
+    subscribe: jest.fn(),
+  },
+}));
 
 describe('Test component: ModelizerTextView', () => {
   let wrapper;
+  let openFileSubscribe;
+  let openFileUnsubscribe;
+  let updateRemoteSubscribe;
+  let updateRemoteUnsubscribe;
+  let checkoutSubscribe;
+  let checkoutUnsubscribe;
+  let emit;
 
   beforeEach(() => {
+    openFileSubscribe = jest.fn();
+    openFileUnsubscribe = jest.fn();
+    updateRemoteSubscribe = jest.fn();
+    updateRemoteUnsubscribe = jest.fn();
+    checkoutSubscribe = jest.fn();
+    checkoutUnsubscribe = jest.fn();
+
+    GitEvent.UpdateRemoteEvent.subscribe.mockImplementation(() => {
+      updateRemoteSubscribe();
+      return { unsubscribe: updateRemoteUnsubscribe };
+    });
+    FileEvent.OpenFileEvent.subscribe.mockImplementation(() => {
+      openFileSubscribe();
+      return { unsubscribe: openFileUnsubscribe };
+    });
+    GitEvent.CheckoutEvent.subscribe.mockImplementation(() => {
+      checkoutSubscribe();
+      return { unsubscribe: checkoutUnsubscribe };
+    });
+
     wrapper = shallowMount(ModelizerTextView, {
       props: {
-        viewType: 'model',
+        viewType: 'text',
+        projectName: 'project-00000000',
       },
-      stubs: {
-        GitBranchCard: true,
+      mocks: {
+        FileEvent,
+        GitEvent,
       },
     });
   });
 
   describe('Test variables initialization', () => {
     describe('Test props: viewType', () => {
-      it('should match "model"', () => {
-        expect(wrapper.vm.viewType).toEqual('model');
+      it('should match "text"', () => {
+        expect(wrapper.vm.viewType).toEqual('text');
       });
+    });
+
+    describe('Test props: projectName', () => {
+      it('should match "project-00000000"', () => {
+        expect(wrapper.vm.projectName).toEqual('project-00000000');
+      });
+    });
+  });
+
+  describe('Test function: onOpenFileEvent', () => {
+    it('should set activeFileId value equal to onOpenFileEvent param.id ', () => {
+      wrapper.vm.onOpenFileEvent({ id: 'terraform/app.tf', label: 'app.tf', content: '' });
+
+      expect(wrapper.vm.activeFileId).toEqual('terraform/app.tf');
+    });
+
+    it('should push the new file to files Array if it is not already there', () => {
+      wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }];
+      wrapper.vm.onOpenFileEvent({ id: 'README.md', label: 'README.md', content: '' });
+
+      expect(wrapper.vm.files).toEqual([{ id: 'terraform/app.tf', label: 'app.tf', content: '' }, { id: 'README.md', label: 'README.md', content: '' }]);
+    });
+
+    it('should not push the new file to files Array if it is already there', () => {
+      wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }];
+      wrapper.vm.onOpenFileEvent({ id: 'terraform/app.tf', label: 'app.tf', content: '' });
+
+      expect(wrapper.vm.files).toEqual([{ id: 'terraform/app.tf', label: 'app.tf', content: '' }]);
+    });
+  });
+
+  describe('Test function: closeFile', () => {
+    beforeEach(() => {
+      emit = jest.fn();
+
+      FileEvent.SelectFileEvent.next.mockImplementation(() => emit());
+    });
+
+    describe('The file to close is contained within files Array', () => {
+      it('should remove file if files length is 2 or more', () => {
+        wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }, { id: 'README.md', label: 'README.md', content: '' }];
+        wrapper.vm.closeFile('terraform/app.tf');
+
+        expect(wrapper.vm.files).toEqual([{ id: 'README.md', label: 'README.md', content: '' }]);
+      });
+
+      it('should remove file if files length is 1', () => {
+        wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }];
+        wrapper.vm.closeFile('terraform/app.tf');
+
+        expect(wrapper.vm.files).toEqual([]);
+      });
+    });
+
+    describe('Closing the active file, then files Array is empty', () => {
+      it('should set activeFileId to an emtpy string and emit the new value', () => {
+        expect(emit).not.toHaveBeenCalled();
+        wrapper.vm.files = [{ id: 'README.md', label: 'README.md', content: '' }];
+        wrapper.vm.activeFileId = 'README.md';
+        wrapper.vm.closeFile('README.md');
+
+        expect(wrapper.vm.files).toHaveLength(0);
+        expect(wrapper.vm.activeFileId).toEqual('');
+        expect(emit).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Closing the active file, then files Array is not empty', () => {
+      it('should set a new value to activeFileId and emit the new value', () => {
+        expect(emit).not.toHaveBeenCalled();
+        wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }, { id: 'README.md', label: 'README.md', content: '' }];
+        wrapper.vm.activeFileId = 'README.md';
+        wrapper.vm.closeFile('README.md');
+
+        expect(wrapper.vm.files).toEqual([{ id: 'terraform/app.tf', label: 'app.tf', content: '' }]);
+        expect(wrapper.vm.files).toHaveLength(1);
+        expect(wrapper.vm.activeFileId).toEqual('terraform/app.tf');
+        expect(emit).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Closing a non active file', () => {
+      it('should not set a new value to activeFileId and not emit the new value', () => {
+        wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: '' }, { id: 'README.md', label: 'README.md', content: '' }];
+        wrapper.vm.activeFileId = 'terraform/app.tf';
+        wrapper.vm.closeFile('README.md');
+
+        expect(wrapper.vm.files).toEqual([{ id: 'terraform/app.tf', label: 'app.tf', content: '' }]);
+        expect(wrapper.vm.files).toHaveLength(1);
+        expect(wrapper.vm.activeFileId).toEqual('terraform/app.tf');
+        expect(emit).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Test function: updateProjectFiles', () => {
+    it('Should update nodes', async () => {
+      wrapper.vm.nodes = [
+        {
+          id: 'terraform',
+          icon: 'fa-solid fa-folder',
+          label: 'terraform',
+          children: [{
+            id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+          }],
+          isFolder: true,
+        },
+        {
+          id: 'branch.txt', icon: 'fa-regular fa-file', label: 'branch.txt', isFolder: false,
+        },
+      ];
+
+      wrapper.vm.updateProjectFiles();
+      await flushPromises();
+      expect(wrapper.vm.nodes).toEqual([
+        {
+          id: 'terraform',
+          icon: 'fa-solid fa-folder',
+          label: 'terraform',
+          children: [{
+            id: 'terraform/app.tf', icon: 'fa-regular fa-file', label: 'app.tf', isFolder: false,
+          }],
+          isFolder: true,
+        },
+      ]);
+    });
+
+    it('Should update files', async () => {
+      wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: 'content' }];
+      wrapper.vm.updateProjectFiles();
+      await flushPromises();
+      expect(wrapper.vm.files).toEqual([{ id: 'terraform/app.tf', content: 'new content', label: 'app.tf' }]);
+    });
+
+    it('Should update active file if it is no more contained in updated files', async () => {
+      wrapper.vm.files = [{ id: 'README.md', label: 'README.md', content: 'content' }, { id: 'terraform/app.tf', label: 'app.tf', content: 'content' }];
+      wrapper.vm.activeFileId = 'README.md';
+
+      wrapper.vm.updateProjectFiles();
+      await flushPromises();
+      expect(wrapper.vm.activeFileId).toEqual('terraform/app.tf');
+    });
+
+    it('Should update active file if it is no more contained in updated empty files', async () => {
+      wrapper.vm.files = [{ id: 'README.md', label: 'README.md', content: 'content' }];
+      wrapper.vm.activeFileId = 'README.md';
+
+      wrapper.vm.updateProjectFiles();
+      await flushPromises();
+      expect(wrapper.vm.activeFileId).toEqual('');
+    });
+
+    it('Should not update active file if it is still contained in updated files', async () => {
+      wrapper.vm.files = [{ id: 'terraform/app.tf', label: 'app.tf', content: 'other content' }, { id: 'README.md', label: 'README.md', content: 'content' }];
+      wrapper.vm.activeFileId = 'terraform/app.tf';
+
+      wrapper.vm.updateProjectFiles();
+      await flushPromises();
+      expect(wrapper.vm.activeFileId).toEqual('terraform/app.tf');
+    });
+  });
+
+  describe('Test hook function: onMounted', () => {
+    it('should subscribe to OpenFileEvent', () => {
+      expect(openFileSubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should subscribe to UpdateRemoteEvent', () => {
+      expect(updateRemoteSubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should subscribe to CheckoutEvent', () => {
+      expect(checkoutSubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onUnmounted', () => {
+    it('should unsubscribe to OpenFileEvent', () => {
+      expect(openFileUnsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(openFileUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe to UpdateRemoteEvent', () => {
+      expect(updateRemoteUnsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(updateRemoteUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe to Checkout', () => {
+      expect(checkoutUnsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(checkoutUnsubscribe).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/components/editor/MonacoEditor.spec.js
+++ b/tests/unit/components/editor/MonacoEditor.spec.js
@@ -22,12 +22,32 @@ describe('Tess component: MonacoEditor', () => {
   editor.create.mockImplementation(() => ({
     dispose,
     getValue: () => 'testValue',
+    setValue: (v) => v,
     layout,
     onDidChangeModelContent,
   }));
 
   beforeEach(() => {
-    wrapper = shallowMount(MonacoEditor);
+    wrapper = shallowMount(MonacoEditor, {
+      props: {
+        viewType: 'text',
+        content: 'Hello World',
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: viewType', () => {
+      it('should match "text"', () => {
+        expect(wrapper.vm.props.viewType).toEqual('text');
+      });
+    });
+
+    describe('Test props: content', () => {
+      it('should match "Hello World"', () => {
+        expect(wrapper.vm.props.content).toEqual('Hello World');
+      });
+    });
   });
 
   describe('Test function: createEditor', () => {
@@ -50,6 +70,16 @@ describe('Tess component: MonacoEditor', () => {
         height: 10,
         width: 11,
       });
+    });
+  });
+
+  describe('Test watcher: props.content', () => {
+    it('should be trigger when props.content is update with a different value', async () => {
+      await wrapper.setProps({
+        viewType: 'text',
+        content: 'new content',
+      });
+      expect(wrapper.vm.props.content).toEqual('new content');
     });
   });
 });

--- a/tests/unit/components/tab/FileTabs.spec.js
+++ b/tests/unit/components/tab/FileTabs.spec.js
@@ -1,0 +1,83 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import FileTabs from 'src/components/tab/FileTabs.vue';
+
+installQuasarPlugin();
+
+describe('Test component: FileTabs', () => {
+  let wrapper;
+  const $emit = jest.fn();
+
+  beforeEach(() => {
+    wrapper = shallowMount(FileTabs, {
+      props: {
+        files: [{ id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }],
+        modelValue: 'terraform/app.tf',
+      },
+      mocks: {
+        $emit,
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: files', () => {
+      it('should match files', () => {
+        const files = [{ id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }];
+
+        expect(wrapper.vm.props.files).toEqual(files);
+      });
+    });
+
+    describe('Test props: modelValue', () => {
+      it('should match modelValue', () => {
+        const modelValue = 'terraform/app.tf';
+
+        expect(wrapper.vm.props.modelValue).toEqual(modelValue);
+      });
+    });
+  });
+
+  describe('Test watcher: props.modelValue', () => {
+    it('should be triggered when props.modelValue is updated with a different value', async () => {
+      await wrapper.setProps({
+        files: [{ id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }],
+        modelValue: 'README.md',
+      });
+
+      expect(wrapper.vm.internalActiveFile).toEqual('README.md');
+    });
+  });
+
+  describe('Test watcher: internalActiveFile', () => {
+    it('should be triggered when internalActiveFile value is updated and not equal to props.modelValue', async () => {
+      await wrapper.setProps({
+        files: [{ id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }],
+        modelValue: 'README.md',
+      });
+
+      wrapper.vm.internalActiveFile = 'terraform/app.tf';
+
+      expect(wrapper.vm.props.modelValue).not.toEqual(wrapper.vm.internalActiveFile);
+
+      wrapper.vm.$emit('update:modelValue', 'terraform/app.tf');
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted()['update:modelValue']).toBeTruthy();
+      expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['terraform/app.tf']);
+    });
+
+    it('should not be triggered when internalActiveFile value is updated and equal to props.modelValue', async () => {
+      await wrapper.setProps({
+        files: [{ id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }],
+        modelValue: 'README.md',
+      });
+
+      wrapper.vm.internalActiveFile = 'README.md';
+
+      expect(wrapper.vm.props.modelValue).toEqual(wrapper.vm.internalActiveFile);
+      expect(wrapper.emitted()['update:modelValue']).toBeFalsy();
+    });
+  });
+});

--- a/tests/unit/composables/events/FileEvent.spec.js
+++ b/tests/unit/composables/events/FileEvent.spec.js
@@ -1,0 +1,18 @@
+import FileEvent from 'src/composables/events/FileEvent';
+import { Subject } from 'rxjs';
+
+describe('Test composable: FileEvent', () => {
+  describe('Test event: OpenFileEvent', () => {
+    it('Should export a Subject', () => {
+      expect(FileEvent.OpenFileEvent).toBeDefined();
+      expect(FileEvent.OpenFileEvent).toEqual(new Subject());
+    });
+  });
+
+  describe('Test event: SelectFileEvent', () => {
+    it('Should export a Subject', () => {
+      expect(FileEvent.SelectFileEvent).toBeDefined();
+      expect(FileEvent.SelectFileEvent).toEqual(new Subject());
+    });
+  });
+});


### PR DESCRIPTION
- Double click on a file opens a tab and display file content inside Monaco Editor
- Switch between tab or double click on file changes the current active tab
- When checkout a branch, the file explorer list and tab content are updated
- If a tab is opened and the corresponding file no longer exists after checkout, the tab is removed
- If the active tab is closed or removed and there is at least one other opened file, this file become the active tab