### PR TITLE
Feature - add/delete file & folder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add root folder in file explorer with project name as label
 - Update PluginEvent for action menu
 - Add fs writeProjectFile & createProjectFolder in Project composable
+- Add create and delete file or folder action
 
 [unreleased]: https://github.com/ditrit/leto-modelizer/blob/main/changelog.md#unreleased

--- a/cypress/e2e/file/file_explorer.feature
+++ b/cypress/e2e/file/file_explorer.feature
@@ -26,8 +26,7 @@ Feature: Test file explorer and file tabs
     And  I expect "[data-cy=\"git-current-branch\"]" is "test/remote"
     And  I click on body to close popup
     Then I expect "[data-cy=\"file-explorer\"]" exists
-    And  I expect "[data-cy=\"file-explorer-leto-modelizer-project-test\"]" exists
-    And  I click on "[data-cy=\"file-explorer-leto-modelizer-project-test\"]"
+    And  I click on "[data-cy=\"file-explorer\"]"
 
   Scenario: Double click on a file should open a tab
     When I double click on "[data-cy=\"file-explorer-README.md\"]"

--- a/src/components/card/FileExplorerActionCard.vue
+++ b/src/components/card/FileExplorerActionCard.vue
@@ -1,0 +1,57 @@
+<template>
+  <q-btn
+    v-bind="$attrs"
+    round
+    flat
+    dense
+    size="xs"
+    :class="['tree-action-button', { 'inline-block' : isActionMenuOpen }]"
+    color="primary"
+    icon="fa-solid fa-ellipsis-vertical"
+    @click.stop="updateSelectedNode"
+  >
+    <file-explorer-action-menu
+      :file="file"
+      @hide:menu="isActionMenuOpen = false"
+    />
+  </q-btn>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import FileEvent from 'src/composables/events/FileEvent';
+import FileExplorerActionMenu from 'components/menu/FileExplorerActionMenu';
+
+const isActionMenuOpen = ref(false);
+
+const props = defineProps({
+  file: {
+    type: Object,
+    required: true,
+  },
+});
+
+/**
+ * Emit SelectNodeEvent and set isActionMenuOpen to true.
+ */
+function updateSelectedNode() {
+  FileEvent.SelectNodeEvent.next(props.file);
+  isActionMenuOpen.value = true;
+}
+</script>
+
+<style lang="scss" scoped>
+.inline-block {
+  display: inline-block
+}
+</style>
+
+<style lang="scss">
+/*
+ * Target tree action button icon to override quasar `.q-icon` default font-size of 21px.
+ * This style is not applied if used within scoped style.
+ */
+.tree-action-button .q-icon {
+  font-size: 14px !important
+}
+</style>

--- a/src/components/dialog/CreateFileDialog.vue
+++ b/src/components/dialog/CreateFileDialog.vue
@@ -1,0 +1,58 @@
+<template>
+  <default-dialog dialog-key="CreateFile" data-cy="create-file-dialog">
+    <template v-slot:title>
+      <q-icon
+        color="primary"
+        name="fa-solid fa-file-circle-plus"
+      />
+      {{ $t(`page.modelizer.fileExplorer.create.${onFolder ? 'folder' : 'file'}.title`) }}
+    </template>
+    <template v-slot:default>
+      <create-file-form
+        :project-name="projectName"
+        :file="newFile"
+        :isFolder="onFolder"
+        @file:create="DialogEvent.next({ type: 'close', key: 'CreateFile' })"
+      />
+    </template>
+  </default-dialog>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+import DialogEvent from 'src/composables/events/DialogEvent';
+import DefaultDialog from 'components/dialog/DefaultDialog';
+import CreateFileForm from 'components/form/CreateFileForm';
+
+defineProps({
+  projectName: {
+    type: String,
+    required: true,
+  },
+});
+
+const newFile = ref(null);
+const onFolder = ref(null);
+let dialogEventSubscription;
+
+/**
+ * Set newFile and onFolder on valid event.
+ * @param {String} key - Event key.
+ * @param {Object} file - Event file.
+ * @param {Boolean} isFolder - True if file node is a folder, otherwise false.
+ */
+function setFileNode({ key, file, isFolder }) {
+  if (key === 'CreateFile') {
+    newFile.value = file;
+    onFolder.value = isFolder;
+  }
+}
+
+onMounted(() => {
+  dialogEventSubscription = DialogEvent.subscribe(setFileNode);
+});
+
+onUnmounted(() => {
+  dialogEventSubscription.unsubscribe();
+});
+</script>

--- a/src/components/dialog/DeleteFileDialog.vue
+++ b/src/components/dialog/DeleteFileDialog.vue
@@ -1,0 +1,68 @@
+<template>
+  <default-dialog dialog-key="DeleteFile" data-cy="delete-file-dialog">
+    <template v-slot:title>
+      <q-icon
+        color="primary"
+        :name="isFolder ? 'fa-solid fa-folder-minus' : 'fa-solid fa-file-circle-minus'"
+      />
+      {{ $t(`page.modelizer.fileExplorer.delete.${ isFolder ? 'folder' : 'file' }.title`) }}
+    </template>
+    <template v-slot:default>
+      <div
+        class="q-pb-lg"
+        v-html="$t(
+          `page.modelizer.fileExplorer.delete.${ isFolder ? 'folder' : 'file' }.description`,
+          { name: deletedFile.label },
+        )"
+      >
+      </div>
+      <delete-file-form
+        :project-name="projectName"
+        :file="deletedFile"
+        @file:delete="DialogEvent.next({ type: 'close', key: 'DeleteFile' })"
+      />
+    </template>
+  </default-dialog>
+</template>
+
+<script setup>
+import {
+  ref,
+  computed,
+  onMounted,
+  onUnmounted,
+} from 'vue';
+import DialogEvent from 'src/composables/events/DialogEvent';
+import DefaultDialog from 'components/dialog/DefaultDialog';
+import DeleteFileForm from 'components/form/DeleteFileForm';
+
+defineProps({
+  projectName: {
+    type: String,
+    required: true,
+  },
+});
+
+const deletedFile = ref(null);
+const isFolder = computed(() => deletedFile.value.isFolder);
+let dialogEventSubscription;
+
+/**
+ * Set deletedFile on valid event.
+ * @param {String} key - Event key.
+ * @param {Object} file - Event file.
+ */
+function setDeletedFile({ key, file }) {
+  if (key === 'DeleteFile') {
+    deletedFile.value = file;
+  }
+}
+
+onMounted(() => {
+  dialogEventSubscription = DialogEvent.subscribe(setDeletedFile);
+});
+
+onUnmounted(() => {
+  dialogEventSubscription.unsubscribe();
+});
+</script>

--- a/src/components/form/CreateFileForm.vue
+++ b/src/components/form/CreateFileForm.vue
@@ -1,0 +1,99 @@
+<template>
+  <q-form
+    @submit="onSubmit"
+    data-cy="create-file-form"
+    class="q-gutter-md create-file-form"
+  >
+    <q-input
+      v-model="fileName"
+      filled
+      :label="$t(`page.modelizer.fileExplorer.create.${isFolder ? 'folder' : 'file'}.input`)"
+      lazy-rules
+      data-cy="create-file-input"
+      :rules="[
+        (v) => notEmpty(t, v),
+        (v) => isValidFileLabel($t, v),
+        (v) => isUniqueFileLabel($t, file.children, v),
+      ]"
+    />
+    <div class="flex row items-center justify-center">
+      <q-btn
+        icon="fa-solid fa-save"
+        :label="$t('actions.default.save')"
+        type="submit"
+        :loading="submitting"
+        data-cy="create-file-submit"
+        color="positive"
+      >
+        <template v-slot:loading>
+          <q-spinner-dots/>
+        </template>
+      </q-btn>
+    </div>
+  </q-form>
+</template>
+
+<script setup>
+import { Notify } from 'quasar';
+import { useI18n } from 'vue-i18n';
+import { ref } from 'vue';
+import { notEmpty, isValidFileLabel, isUniqueFileLabel } from 'src/composables/QuasarFieldRule';
+import { createProjectFolder, writeProjectFile } from 'src/composables/Project';
+import { FileInput } from 'leto-modelizer-plugin-core';
+
+const props = defineProps({
+  projectName: {
+    type: String,
+    required: true,
+  },
+  file: {
+    type: Object,
+    required: true,
+  },
+  isFolder: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['file:create']);
+const { t } = useI18n();
+const fileName = ref('');
+const submitting = ref(false);
+
+/**
+ * Emit new fileName and send positive toast.
+ */
+function onSubmit() {
+  const parent = props.file.id === props.projectName ? '' : `${props.file.id}/`;
+  const promise = props.isFolder ? createProjectFolder : writeProjectFile;
+  const path = props.isFolder ? `${parent}${fileName.value}` : new FileInput({
+    path: `${parent}${fileName.value}`,
+    content: ' ',
+  });
+  submitting.value = true;
+
+  return promise(props.projectName, path).then(() => {
+    emit('file:create', fileName.value);
+    Notify.create({
+      type: 'positive',
+      message: t('actions.fileExplorer.file.create'),
+      html: true,
+    });
+  }).catch(() => {
+    Notify.create({
+      type: 'negative',
+      message: t(`errors.fileExplorer.default.${props.isFolder ? 'folder' : 'file'}.create`),
+      html: true,
+    });
+  }).finally(() => {
+    submitting.value = false;
+  });
+}
+</script>
+
+<style lang="scss">
+.create-file-form {
+  min-width: 400px;
+}
+</style>

--- a/src/components/form/DeleteFileForm.vue
+++ b/src/components/form/DeleteFileForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <q-form
+    @submit="onSubmit"
+    data-cy="delete-file-form"
+    class="q-gutter-md git-form"
+  >
+    <q-checkbox
+      v-if="isFolderWithChildren"
+      v-model="confirmDelete"
+      data-cy="git-confirm-delete-checkbox"
+      :label="$t('page.modelizer.fileExplorer.delete.folder.confirmDelete')"
+    />
+    <div class="flex row items-center justify-center">
+      <q-btn
+        icon="fa-solid fa-trash"
+        :label="$t('actions.default.delete')"
+        type="submit"
+        :loading="submitting"
+        :disable="isFolderWithChildren && !confirmDelete"
+        data-cy="delete-file-submit"
+        color="negative"
+      >
+        <template v-slot:loading>
+          <q-spinner-dots/>
+        </template>
+      </q-btn>
+    </div>
+  </q-form>
+</template>
+
+<script setup>
+import { Notify } from 'quasar';
+import { deleteProjectFile } from 'src/composables/Project';
+import { useI18n } from 'vue-i18n';
+import { ref, computed } from 'vue';
+
+const emit = defineEmits(['file:delete']);
+
+const props = defineProps({
+  projectName: {
+    type: String,
+    required: true,
+  },
+  file: {
+    type: Object,
+    required: true,
+  },
+});
+
+const isFolderWithChildren = computed(() => props.file.isFolder
+  && props.file.children.length !== 0);
+
+const { t } = useI18n();
+const confirmDelete = ref(false);
+const submitting = ref(false);
+
+/**
+ * Emit new fileName if form is valid and manage toast.
+ */
+function onSubmit() {
+  if (isFolderWithChildren.value && !confirmDelete.value) {
+    return Notify.create({
+      type: 'negative',
+      message: t('errors.fileExplorer.folder.delete'),
+      html: true,
+    });
+  }
+
+  submitting.value = true;
+
+  return deleteProjectFile(props.projectName, props.file.id, props.file.isFolder)
+    .then(() => {
+      emit('file:delete');
+      Notify.create({
+        type: 'positive',
+        message: t(`actions.fileExplorer.${props.file.isFolder ? 'folder' : 'file'}.delete`),
+        html: true,
+      });
+    })
+    .catch(() => {
+      Notify.create({
+        type: 'negative',
+        message: t(`errors.fileExplorer.default.${props.isFolder ? 'folder' : 'file'}.delete`),
+        html: true,
+      });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+}
+</script>

--- a/src/components/menu/FileExplorerActionMenu.vue
+++ b/src/components/menu/FileExplorerActionMenu.vue
@@ -1,0 +1,88 @@
+<template>
+  <q-menu
+    @hide="emit('hide:menu')"
+    class="tree-action-menu"
+    data-cy="tree-action-menu"
+    auto-close
+  >
+    <q-list style="min-width: 150px">
+      <template v-if="file.isFolder">
+        <q-item clickable @click="addFile(true)">
+          <q-item-section avatar>
+            <q-icon
+              color="primary"
+              size="xs"
+              name="fa-solid fa-folder-plus"
+              data-cy="tree-action-add-folder"
+            />
+          </q-item-section>
+          <q-item-section>
+            {{ $t('actions.fileExplorer.newFolder') }}
+          </q-item-section>
+        </q-item>
+        <q-item clickable @click="addFile(false)">
+          <q-item-section avatar>
+            <q-icon
+              color="primary"
+              size="xs"
+              name="fa-solid fa-file-circle-plus"
+              data-cy="tree-action-add-file"
+            />
+          </q-item-section>
+          <q-item-section>
+            {{ $t('actions.fileExplorer.newFile') }}
+          </q-item-section>
+        </q-item>
+      </template>
+      <q-item v-if="!file.isRootFolder" clickable @click="deleteFile">
+        <q-item-section avatar>
+          <q-icon
+            color="primary"
+            size="xs"
+            name="fa-solid fa-trash"
+            data-cy="tree-action-delete-file"
+          />
+        </q-item-section>
+        <q-item-section>
+          {{ $t('actions.default.delete') }}
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-menu>
+</template>
+
+<script setup>
+import DialogEvent from 'src/composables/events/DialogEvent';
+
+const emit = defineEmits(['hide:menu']);
+
+const props = defineProps({
+  file: {
+    type: Object,
+    required: true,
+  },
+});
+
+/**
+ * Send event to open the CreateFileDialog.
+ */
+function addFile(isFolder) {
+  DialogEvent.next({
+    type: 'open',
+    key: 'CreateFile',
+    file: props.file,
+    isFolder,
+  });
+}
+
+/**
+ * Send event to open the DeleteFileDialog.
+ */
+function deleteFile() {
+  DialogEvent.next({
+    type: 'open',
+    key: 'DeleteFile',
+    file: props.file,
+  });
+}
+</script>

--- a/src/composables/FileExplorer.js
+++ b/src/composables/FileExplorer.js
@@ -1,12 +1,10 @@
-import { getProjectName } from 'src/composables/Project';
-
 /**
  * Create and add a new folder.
  * @param {String} id - Absolute path of folder.
- * @param {Array} folder - Folder that will receive an empty folder Object
+ * @param {Array} folder - Folder that will receive an new empty folder.
  * @param {String} name - Name of the new folder.
  */
-function createFolder(id, folder, name) {
+export function createFolder(id, folder, name) {
   folder.push({
     id,
     icon: 'fa-solid fa-folder',
@@ -19,15 +17,20 @@ function createFolder(id, folder, name) {
 /**
  * Create and add a new file.
  * @param {String} id - Absolute path of file.
- * @param {Array} folder - Folder that will receive an empty file Object
- * @param {String} name - Name of the new folder.
+ * @param {Array} folder - Folder that will receive a new empty file.
+ * @param {String} name - Name of the new file.
+ * @param {Boolean} [isNewLocalFile=true] - True when the file is locally created otherwise false.
  */
-function createFile(id, folder, name) {
+export function createFile(id, folder, name, isNewLocalFile = true) {
+  if (name === '__empty__') {
+    return;
+  }
   folder.push({
     id,
     icon: 'fa-regular fa-file',
     label: name,
     isFolder: false,
+    isNewLocalFile,
   });
 }
 
@@ -54,7 +57,7 @@ function getTreeFolderChildrenFromPath(folders, paths) {
  * @returns {Array} - Sorted Tree
  */
 function sortElementsInFolder(elements) {
-  elements.sort((x, y) => {
+  return elements.sort((x, y) => {
     if (x.isFolder && !y.isFolder) {
       return -1;
     }
@@ -70,7 +73,7 @@ function sortElementsInFolder(elements) {
  * @param {Array} elements - Tree folders
  * @returns {Array} - Sorted Tree
  */
-function sortTreeElements(elements) {
+export function sortTreeElements(elements) {
   sortElementsInFolder(elements);
   elements.filter((element) => element.children && element.children.length > 0)
     .forEach((element) => sortTreeElements(element.children));
@@ -86,7 +89,6 @@ function sortTreeElements(elements) {
  * @see https://quasar.dev/vue-components/tree
  */
 export function getTree(projectId, fileInformationArray) {
-  const projectName = getProjectName(projectId);
   const tree = [];
   fileInformationArray.forEach((fileInformation) => {
     const splittedPath = fileInformation.path.split('/').filter(Boolean);
@@ -96,11 +98,11 @@ export function getTree(projectId, fileInformationArray) {
       if (!parentFolderChildren.length
         || parentFolderChildren.every((child) => child.label !== pathName)) {
         if (index === splittedPath.length - 1) {
-          createFile(fileInformation.path, parentFolderChildren, pathName);
+          createFile(fileInformation.path, parentFolderChildren, pathName, false);
         } else {
           createFolder(
             fileInformation.path
-              .substr(0, fileInformation.path.indexOf(pathName) + pathName.length),
+              .substring(0, fileInformation.path.indexOf(pathName) + pathName.length),
             parentFolderChildren,
             pathName,
           );
@@ -111,10 +113,11 @@ export function getTree(projectId, fileInformationArray) {
 
   return [
     {
-      id: projectName,
+      id: projectId,
       icon: 'fa-solid fa-folder',
-      label: projectName,
+      label: projectId,
       isFolder: true,
+      isRootFolder: true,
       children: sortTreeElements(tree),
     },
   ];

--- a/src/composables/QuasarFieldRule.js
+++ b/src/composables/QuasarFieldRule.js
@@ -20,6 +20,7 @@ export function isGitRepositoryUrl(t, value) {
   return /^http(s)?:\/\/.+\/.*(?<!\.git)$/.test(value)
     || t('errors.invalid.gitProvider.repository');
 }
+
 /**
  * Check if the branch name does not already exist.
  * @param {Function} t - I18n translate function.
@@ -31,4 +32,29 @@ export function isGitRepositoryUrl(t, value) {
 export function isUniqueBranchName(t, branches, value) {
   return branches.every((branch) => branch.name !== value)
     || t('errors.git.branch.duplicate');
+}
+
+/**
+ * Check if value is a valid file label.
+ * @param {Function} t - I18n translate function.
+ * @param {String} value - Value to check.
+ * @return {boolean|String} Return true if valid otherwise the translated error message.
+ */
+export function isValidFileLabel(t, value) {
+  return !value.includes('/')
+    || t('errors.invalid.fileExplorer.label');
+}
+
+/**
+ * Check if a file's label does not already exist.
+ * @param {Function} t - I18n translate function.
+ * @param {Object[]} tree - Tree Object.
+ * @param {String} tree.label - Label of a file.
+ * @param {String} value - Value to check.
+ * @return {boolean|String} Return true if the node label doesn't already exist,
+ * otherwise the translated error message.
+ */
+export function isUniqueFileLabel(t, tree, value) {
+  return tree.every(({ label }) => label !== value)
+    || t('errors.fileExplorer.label.duplicate');
 }

--- a/src/composables/events/FileEvent.js
+++ b/src/composables/events/FileEvent.js
@@ -4,20 +4,52 @@ import { Subject } from 'rxjs';
  * Represent a rxjs Event object to emit and to receive events about file opening.
  * The event should be an Object that contains the `id` (path), the `label`
  * and the `content` of the file.
- * Example: { id: 'terraform/app.tf', label: 'app.tf', content: 'Hello World' }
  * @typedef {Subject} OpenFileEvent
  */
 const OpenFileEvent = new Subject();
 
 /**
  * Represent a rxjs Event object to emit and to receive events about file selecting.
- * The event should be an Object that contains the `id` (path) of the file and `isSelected` boolean.
+ * The event should be an Object that contains the `id` (path) of the file and `isSelected`.
  * Example: { isSelected: true, id: 'terraform/app.tf' }
  * @typedef {Subject} SelectFileEvent
  */
 const SelectFileEvent = new Subject();
 
+/**
+ * Represent a rxjs Event object to emit and to receive events about node selection.
+ * The event should be an Object that contains the `id` (path), `label`, `icon` and `isFolder`.
+ * The Object should also contain `isNewLocalFile` for a file, or `children` for a folder.
+ * @typedef {Subject} SelectFileEvent
+ */
+const SelectNodeEvent = new Subject();
+
+/**
+ * Represent a rxjs Event object to emit and to receive events about file creation.
+ * The event should be an Object that contains the `name` (path) of the file and `isFolder`.
+ * @typedef {Subject} SelectFileEvent
+ */
+const CreateFileEvent = new Subject();
+
+/**
+ * Represent a rxjs Event object to emit and to receive events about node deletion.
+ * The event should be an Object that contains `deletedNode` for the node Object to delete
+ * and `parentNode` for the deleted node's parent Object.
+ * @typedef {Subject} SelectFileEvent
+ */
+const DeleteFileEvent = new Subject();
+
+/**
+ * Represent a rxjs Event object to emit and to receive events about node expansion.
+ * @typedef {Subject} SelectFileEvent
+ */
+const ExpandFolderEvent = new Subject();
+
 export default {
   OpenFileEvent,
   SelectFileEvent,
+  SelectNodeEvent,
+  CreateFileEvent,
+  DeleteFileEvent,
+  ExpandFolderEvent,
 };

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -6,6 +6,7 @@ export default {
     default: {
       goToHome: 'Go to homepage',
       save: 'Save',
+      delete: 'Delete',
       show: {
         more: 'Show {number} more...',
         less: 'Show less',
@@ -31,6 +32,16 @@ export default {
     },
     fileExplorer: {
       empty: 'No files available in project.',
+      newFile: 'New file',
+      newFolder: 'New folder',
+      file: {
+        create: 'File is created &#129395;!',
+        delete: 'File is deleted.',
+      },
+      folder: {
+        create: 'Folder is created &#129395;!',
+        delete: 'Folder is deleted.',
+      },
     },
   },
   errors: {
@@ -38,6 +49,9 @@ export default {
     invalid: {
       gitProvider: {
         repository: 'Invalid repository url',
+      },
+      fileExplorer: {
+        label: 'The name must not contain any \'/ \' characters',
       },
     },
     git: {
@@ -47,6 +61,24 @@ export default {
       },
       cannotLockRef: 'Fatal: cannot lock reference.',
       MergeNotSupportedError: 'The remote history has been force rewritten, we haven\'t implemented yet the rebase option(<code>git pull -r</code>).<br/>Please delete and checkout once again your branch.',
+    },
+    fileExplorer: {
+      folder: {
+        delete: 'You must confirm the deletion of the file and its content.',
+      },
+      label: {
+        duplicate: 'This name already exists.',
+      },
+      default: {
+        folder: {
+          create: 'An error occured while creating folder.',
+          delete: 'An error occured while deleting folder.',
+        },
+        file: {
+          create: 'An error occured while creating file.',
+          delete: 'An error occured while deleting file.',
+        },
+      },
     },
   },
   projects: {
@@ -89,6 +121,29 @@ export default {
           title: 'Update',
           description: 'Do you want to update your branch <b>{branch}</b> ?',
           fastForward: 'Fast forward option (<code>git pull --ff</code>)',
+        },
+      },
+      fileExplorer: {
+        create: {
+          file: {
+            title: 'Create a new file',
+            input: 'New file name',
+          },
+          folder: {
+            title: 'Create a new folder',
+            input: 'New folder name',
+          },
+        },
+        delete: {
+          file: {
+            title: 'Delete file',
+            description: 'Are you sure you want to delete <b>{name}</b> file ?',
+          },
+          folder: {
+            title: 'Delete folder',
+            description: 'Are you sure you want to delete <b>{name}</b> folder ?',
+            confirmDelete: 'Confirm deletion of folder and all its content',
+          },
         },
       },
     },

--- a/src/pages/ModelizerPage.vue
+++ b/src/pages/ModelizerPage.vue
@@ -22,6 +22,8 @@
         <git-configuration-dialog :project-name="projectName"/>
         <git-new-branch-dialog :project-name="projectName"/>
         <git-update-dialog :project-name="projectName"/>
+        <create-file-dialog :project-name="projectName"/>
+        <delete-file-dialog :project-name="projectName"/>
       </q-page>
     </q-page-container>
   </q-layout>
@@ -34,7 +36,6 @@ import {
   computed,
 } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-
 import ModelizerNavigationBar from 'src/components/ModelizerNavigationBar';
 import ModelizerModelView from 'src/components/ModelizerModelView';
 import ModelizerTextView from 'src/components/ModelizerTextView';
@@ -42,6 +43,8 @@ import ViewSwitchEvent from 'src/composables/events/ViewSwitchEvent';
 import GitConfigurationDialog from 'components/dialog/GitConfigurationDialog';
 import GitNewBranchDialog from 'components/dialog/GitNewBranchDialog';
 import GitUpdateDialog from 'components/dialog/GitUpdateDialog';
+import CreateFileDialog from 'components/dialog/CreateFileDialog';
+import DeleteFileDialog from 'components/dialog/DeleteFileDialog';
 
 const route = useRoute();
 const router = useRouter();

--- a/tests/unit/components/FileExplorer.spec.js
+++ b/tests/unit/components/FileExplorer.spec.js
@@ -18,25 +18,36 @@ jest.mock('src/composables/events/FileEvent', () => ({
   SelectFileEvent: {
     subscribe: jest.fn(),
   },
+  ExpandFolderEvent: {
+    subscribe: jest.fn(),
+  },
 }));
 
 describe('Test component: FileExplorer', () => {
   let wrapper;
-  let subscribe;
-  let unsubscribe;
+  let selectFileSubscribe;
+  let selectFileUnsubscribe;
+  let expandNodeSubscribe;
+  let expandNodeUnsubscribe;
 
   const emit = jest.fn();
 
   FileEvent.OpenFileEvent.next.mockImplementation(() => emit());
 
   FileEvent.SelectFileEvent.subscribe.mockImplementation(() => {
-    subscribe();
-    return { unsubscribe };
+    selectFileSubscribe();
+    return { unsubscribe: selectFileUnsubscribe };
+  });
+  FileEvent.ExpandFolderEvent.subscribe.mockImplementation(() => {
+    expandNodeSubscribe();
+    return { unsubscribe: expandNodeUnsubscribe };
   });
 
   beforeEach(() => {
-    subscribe = jest.fn();
-    unsubscribe = jest.fn();
+    selectFileSubscribe = jest.fn();
+    selectFileUnsubscribe = jest.fn();
+    expandNodeSubscribe = jest.fn();
+    expandNodeUnsubscribe = jest.fn();
 
     wrapper = shallowMount(FileExplorer, {
       global: {
@@ -118,17 +129,37 @@ describe('Test component: FileExplorer', () => {
     });
   });
 
+  describe('Test function: setExpandedNode', () => {
+    it('should call setExpanded', () => {
+      wrapper.vm.fileExplorerRef = {
+        setExpanded: jest.fn(),
+      };
+      wrapper.vm.setExpandedNode();
+      expect(wrapper.vm.fileExplorerRef.setExpanded).toBeCalled();
+    });
+  });
+
   describe('Test hook function: onMounted', () => {
     it('should subscribe to SelectFileEvent', () => {
-      expect(subscribe).toHaveBeenCalledTimes(1);
+      expect(selectFileSubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should subscribe to ExpandFolderEvent', () => {
+      expect(expandNodeSubscribe).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('Test hook function: onUnmounted', () => {
     it('should unsubscribe to SelectFileEvent', () => {
-      expect(unsubscribe).toHaveBeenCalledTimes(0);
+      expect(selectFileUnsubscribe).toHaveBeenCalledTimes(0);
       wrapper.unmount();
-      expect(unsubscribe).toHaveBeenCalledTimes(1);
+      expect(selectFileUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe to ExpandFolderEvent', () => {
+      expect(expandNodeUnsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(expandNodeUnsubscribe).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/components/card/FileExplorerActionCard.spec.js
+++ b/tests/unit/components/card/FileExplorerActionCard.spec.js
@@ -1,0 +1,44 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import FileExplorerActionCard from 'src/components/card/FileExplorerActionCard.vue';
+import FileEvent from 'src/composables/events/FileEvent';
+
+installQuasarPlugin();
+
+jest.mock('src/composables/events/FileEvent', () => ({
+  SelectNodeEvent: {
+    next: jest.fn(() => Promise.resolve('SelectNodeEvent')),
+  },
+}));
+
+describe('Test component: FileExplorerActionCard', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(FileExplorerActionCard, {
+      props: {
+        file: { id: 'test' },
+      },
+    });
+  });
+
+  describe('Test props initialization', () => {
+    describe('Test prop: file', () => {
+      it('should match file', () => {
+        expect(wrapper.vm.file).toStrictEqual({ id: 'test' });
+      });
+    });
+  });
+
+  describe('Test functions', () => {
+    describe('Test function: updateSelectedNode', () => {
+      it('should set isActionMenuOpen and call SelectNodeEvent', () => {
+        expect(wrapper.vm.isActionMenuOpen).toBe(false);
+
+        wrapper.vm.updateSelectedNode();
+        expect(wrapper.vm.isActionMenuOpen).toEqual(true);
+        expect(FileEvent.SelectNodeEvent.next).toBeCalled();
+      });
+    });
+  });
+});

--- a/tests/unit/components/dialog/CreateFileDialog.spec.js
+++ b/tests/unit/components/dialog/CreateFileDialog.spec.js
@@ -1,0 +1,78 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import i18nConfiguration from 'src/i18n';
+import CreateFileDialog from 'src/components/dialog/CreateFileDialog';
+import DialogEvent from 'src/composables/events/DialogEvent';
+
+installQuasarPlugin();
+
+jest.mock('src/composables/events/DialogEvent', () => ({
+  subscribe: jest.fn(),
+}));
+
+describe('Test component: CreateFileDialog', () => {
+  let wrapper;
+  let subscribe;
+  let unsubscribe;
+
+  beforeEach(() => {
+    subscribe = jest.fn();
+    unsubscribe = jest.fn();
+
+    DialogEvent.subscribe.mockImplementation(() => {
+      subscribe();
+      return { unsubscribe };
+    });
+
+    wrapper = shallowMount(CreateFileDialog, {
+      props: {
+        projectName: 'projectName',
+      },
+      global: {
+        plugins: [
+          createI18n(i18nConfiguration),
+        ],
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: projectName', () => {
+      it('should match "projectName"', () => {
+        expect(wrapper.vm.projectName).toEqual('projectName');
+      });
+    });
+  });
+
+  describe('Test function: setFileNode', () => {
+    it('should set newFile and onFolder on valid event key', () => {
+      expect(wrapper.vm.newFile).toBeNull();
+      expect(wrapper.vm.onFolder).toBeNull();
+
+      wrapper.vm.setFileNode({ key: 'CreateFile', file: { id: 'test' }, isFolder: true });
+      expect(wrapper.vm.newFile).toEqual({ id: 'test' });
+      expect(wrapper.vm.onFolder).toEqual(true);
+    });
+
+    it('should not set newFile and onFolder on invalid event key', () => {
+      wrapper.vm.setFileNode({ key: 'NotCreateFile', file: { id: 'test' }, isFolder: true });
+      expect(wrapper.vm.newFile).toBeNull();
+      expect(wrapper.vm.onFolder).toBeNull();
+    });
+  });
+
+  describe('Test hook function: onMounted', () => {
+    it('should subscribe DialogEvent', () => {
+      expect(subscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onUnmounted', () => {
+    it('should unsubscribe DialogEvent', () => {
+      expect(unsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/components/dialog/DeleteFileDialog.spec.js
+++ b/tests/unit/components/dialog/DeleteFileDialog.spec.js
@@ -1,0 +1,77 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import i18nConfiguration from 'src/i18n';
+import DeleteFileDialog from 'src/components/dialog/DeleteFileDialog';
+import DialogEvent from 'src/composables/events/DialogEvent';
+
+installQuasarPlugin();
+
+jest.mock('src/composables/events/DialogEvent', () => ({
+  subscribe: jest.fn(),
+}));
+
+describe('Test component: DeleteFileDialog', () => {
+  let wrapper;
+  let subscribe;
+  let unsubscribe;
+
+  beforeEach(() => {
+    subscribe = jest.fn();
+    unsubscribe = jest.fn();
+
+    DialogEvent.subscribe.mockImplementation(() => {
+      subscribe();
+      return { unsubscribe };
+    });
+
+    wrapper = shallowMount(DeleteFileDialog, {
+      props: {
+        projectName: 'projectName',
+      },
+      global: {
+        plugins: [
+          createI18n(i18nConfiguration),
+        ],
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: projectName', () => {
+      it('should match "projectName"', () => {
+        expect(wrapper.vm.projectName).toEqual('projectName');
+      });
+    });
+  });
+
+  describe('Test function: setDeletedFile', () => {
+    it('should set deletedFile on valid event key', () => {
+      expect(wrapper.vm.deletedFile).toBeNull();
+
+      wrapper.vm.setDeletedFile({ file: { id: 'test' }, key: 'DeleteFile' });
+      expect(wrapper.vm.deletedFile).toEqual({ id: 'test' });
+    });
+
+    it('should not set deletedFile on invalid event key', () => {
+      expect(wrapper.vm.deletedFile).toBeNull();
+
+      wrapper.vm.setDeletedFile({ file: { id: 'test' }, key: 'NotDeleteFile' });
+      expect(wrapper.vm.deletedFile).toBeNull();
+    });
+  });
+
+  describe('Test hook function: onMounted', () => {
+    it('should subscribe DialogEvent', () => {
+      expect(subscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onUnmounted', () => {
+    it('should unsubscribe DialogEvent', () => {
+      expect(unsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/components/form/CreateFileForm.spec.js
+++ b/tests/unit/components/form/CreateFileForm.spec.js
@@ -1,0 +1,102 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import CreateFileForm from 'src/components/form/CreateFileForm';
+import { Notify } from 'quasar';
+import { createProjectFolder, writeProjectFile } from 'src/composables/Project';
+
+installQuasarPlugin({
+  plugins: [Notify],
+});
+
+jest.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (t) => t,
+  }),
+}));
+
+jest.mock('src/composables/Project', () => ({
+  createProjectFolder: jest.fn((id) => {
+    if (id === 'error') {
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  }),
+  writeProjectFile: jest.fn((id) => {
+    if (id === 'error') {
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  }),
+}));
+
+describe('Test component: CreateFileForm', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(CreateFileForm, {
+      props: {
+        projectName: 'projectName',
+        file: { id: 'test' },
+        isfolder: false,
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: projectName', () => {
+      it('should match "projectName"', () => {
+        expect(wrapper.vm.projectName).toEqual('projectName');
+      });
+    });
+
+    describe('Test props: file', () => {
+      it('should match file', () => {
+        expect(wrapper.vm.file).toEqual({ id: 'test' });
+      });
+    });
+
+    describe('Test props: isFolder', () => {
+      it('should be false', () => {
+        expect(wrapper.vm.isFolder).toEqual(false);
+      });
+    });
+  });
+
+  describe('Test function: onSubmit', () => {
+    it('should emit an event and a positive notification on success', async () => {
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(wrapper.emitted()['file:create']).toBeTruthy();
+      expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'positive' }));
+    });
+
+    it('should emit a negative notification on error', async () => {
+      await wrapper.setProps({ projectName: 'error' });
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+    });
+
+    it('should call writeProjectFile with file', async () => {
+      await wrapper.setProps({ projectName: 'file', file: { id: 'file' } });
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(writeProjectFile).toBeCalled();
+    });
+
+    it('should call createProjectFolder with folder', async () => {
+      await wrapper.setProps({ isFolder: true });
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(createProjectFolder).toBeCalled();
+    });
+  });
+});

--- a/tests/unit/components/form/DeleteFileForm.spec.js
+++ b/tests/unit/components/form/DeleteFileForm.spec.js
@@ -1,0 +1,96 @@
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import { shallowMount } from '@vue/test-utils';
+import DeleteFileForm from 'src/components/form/DeleteFileForm';
+import { Notify } from 'quasar';
+
+installQuasarPlugin({
+  plugins: [Notify],
+});
+
+jest.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (t) => t,
+  }),
+}));
+
+jest.mock('src/composables/Project', () => ({
+  deleteProjectFile: jest.fn((id) => {
+    if (id === 'error') {
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  }),
+}));
+
+describe('Test component: DeleteFileForm', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(DeleteFileForm, {
+      props: {
+        projectName: 'projectName',
+        file: {
+          id: 'test',
+          children: [1],
+          isFolder: true,
+        },
+      },
+    });
+  });
+
+  describe('Test variables initialization', () => {
+    describe('Test props: projectName', () => {
+      it('should match "projectName"', () => {
+        expect(wrapper.vm.props.projectName).toEqual('projectName');
+      });
+    });
+
+    describe('Test props: file', () => {
+      it('should match file', () => {
+        expect(wrapper.vm.props.file).toEqual({
+          id: 'test',
+          children: [1],
+          isFolder: true,
+        });
+      });
+    });
+  });
+
+  describe('Test function: onSubmit', () => {
+    it('should emit an event and a positive notification on success', async () => {
+      Notify.create = jest.fn();
+      wrapper.vm.confirmDelete = true;
+
+      await wrapper.vm.onSubmit();
+
+      expect(wrapper.vm.confirmDelete).toEqual(true);
+      expect(wrapper.emitted()['file:delete']).toBeTruthy();
+      expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'positive' }));
+    });
+
+    it('should emit a negative notification on error', async () => {
+      await wrapper.setProps({ projectName: 'error', file: { isFolder: false } });
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+    });
+
+    it('should emit a negative notification on error without confirm deletion', async () => {
+      await wrapper.setProps({
+        projectName: 'error',
+        file: {
+          isFolder: true,
+          children: [1],
+        },
+      });
+      wrapper.vm.confirmDelete = false;
+      Notify.create = jest.fn();
+
+      await wrapper.vm.onSubmit();
+
+      expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'negative' }));
+    });
+  });
+});

--- a/tests/unit/components/menu/FileExplorerActionMenu.spec.js
+++ b/tests/unit/components/menu/FileExplorerActionMenu.spec.js
@@ -1,0 +1,64 @@
+import { shallowMount } from '@vue/test-utils';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
+import DialogEvent from 'src/composables/events/DialogEvent';
+import FileExplorerActionMenu from 'components/menu/FileExplorerActionMenu';
+
+installQuasarPlugin();
+
+describe('Test component: FileExplorerActionMenu', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(FileExplorerActionMenu, {
+      props: {
+        file: { id: 'test' },
+      },
+    });
+  });
+
+  describe('Test props initialization', () => {
+    describe('Test prop: file', () => {
+      it('should match file', () => {
+        expect(wrapper.vm.file).toStrictEqual({ id: 'test' });
+      });
+    });
+  });
+
+  describe('Test functions', () => {
+    describe('Test function: addFile', () => {
+      it('should call dialog event to create file', () => {
+        DialogEvent.next = jest.fn(() => Promise.resolve({
+          type: 'open',
+          key: 'CreateFile',
+          file: wrapper.vm.file,
+          isFolder: false,
+        }));
+        wrapper.vm.addFile(false);
+        expect(DialogEvent.next).toBeCalled();
+      });
+
+      it('should call dialog event to create folder', () => {
+        DialogEvent.next = jest.fn(() => Promise.resolve({
+          type: 'open',
+          key: 'CreateFile',
+          file: wrapper.vm.file,
+          isFolder: true,
+        }));
+        wrapper.vm.addFile(true);
+        expect(DialogEvent.next).toBeCalled();
+      });
+    });
+
+    describe('Test function: deleteFile', () => {
+      it('should call dialog event', () => {
+        DialogEvent.next = jest.fn(() => Promise.resolve({
+          type: 'open',
+          key: 'DeleteFile',
+          file: wrapper.vm.file,
+        }));
+        wrapper.vm.deleteFile();
+        expect(DialogEvent.next).toBeCalled();
+      });
+    });
+  });
+});

--- a/tests/unit/composables/FileExplorer.spec.js
+++ b/tests/unit/composables/FileExplorer.spec.js
@@ -11,12 +11,14 @@ describe('Test composable: FileExplorer', () => {
           icon: 'fa-solid fa-folder',
           label: 'my-project',
           isFolder: true,
+          isRootFolder: true,
           children: [
             {
               id: '/file.tf',
               label: 'file.tf',
               icon: 'fa-regular fa-file',
               isFolder: false,
+              isNewLocalFile: false,
             },
           ],
         }];
@@ -33,18 +35,21 @@ describe('Test composable: FileExplorer', () => {
           icon: 'fa-solid fa-folder',
           label: 'my-project',
           isFolder: true,
+          isRootFolder: true,
           children: [
             {
               id: '/file1.tf',
               label: 'file1.tf',
               icon: 'fa-regular fa-file',
               isFolder: false,
+              isNewLocalFile: false,
             },
             {
               id: '/file2.tf',
               label: 'file2.tf',
               icon: 'fa-regular fa-file',
               isFolder: false,
+              isNewLocalFile: false,
             },
           ],
         }];
@@ -61,6 +66,7 @@ describe('Test composable: FileExplorer', () => {
           icon: 'fa-solid fa-folder',
           label: 'my-project',
           isFolder: true,
+          isRootFolder: true,
           children: [
             {
               id: '/home',
@@ -73,6 +79,7 @@ describe('Test composable: FileExplorer', () => {
                   label: 'file.tf',
                   icon: 'fa-regular fa-file',
                   isFolder: false,
+                  isNewLocalFile: false,
                 },
               ],
             },
@@ -91,6 +98,7 @@ describe('Test composable: FileExplorer', () => {
           icon: 'fa-solid fa-folder',
           label: 'my-project',
           isFolder: true,
+          isRootFolder: true,
           children: [
             {
               id: '/home',
@@ -103,12 +111,14 @@ describe('Test composable: FileExplorer', () => {
                   label: 'file1.tf',
                   icon: 'fa-regular fa-file',
                   isFolder: false,
+                  isNewLocalFile: false,
                 },
                 {
                   id: '/home/file2.tf',
                   label: 'file2.tf',
                   icon: 'fa-regular fa-file',
                   isFolder: false,
+                  isNewLocalFile: false,
                 },
               ],
             },
@@ -131,6 +141,7 @@ describe('Test composable: FileExplorer', () => {
           icon: 'fa-solid fa-folder',
           label: 'my-project',
           isFolder: true,
+          isRootFolder: true,
           children: [
             {
               id: '/home',
@@ -155,6 +166,7 @@ describe('Test composable: FileExplorer', () => {
                           label: 'file1.tf',
                           icon: 'fa-regular fa-file',
                           isFolder: false,
+                          isNewLocalFile: false,
                         },
                       ],
                     },
@@ -163,6 +175,7 @@ describe('Test composable: FileExplorer', () => {
                       label: 'file2.tf',
                       icon: 'fa-regular fa-file',
                       isFolder: false,
+                      isNewLocalFile: false,
                     },
                   ],
                 },
@@ -185,6 +198,7 @@ describe('Test composable: FileExplorer', () => {
                       label: 'file3.tf',
                       icon: 'fa-regular fa-file',
                       isFolder: false,
+                      isNewLocalFile: false,
                     },
                   ],
                 },
@@ -202,6 +216,7 @@ describe('Test composable: FileExplorer', () => {
         icon: 'fa-solid fa-folder',
         label: 'my-project',
         isFolder: true,
+        isRootFolder: true,
         children: [],
       }]);
     });

--- a/tests/unit/composables/Project.spec.js
+++ b/tests/unit/composables/Project.spec.js
@@ -15,9 +15,11 @@ import {
   checkout,
   createBranchFrom,
   gitUpdate,
-  PROJECT_STORAGE_KEY,
   createProjectFolder,
   writeProjectFile,
+  rmDir,
+  rm,
+  PROJECT_STORAGE_KEY,
 } from 'src/composables/Project';
 import { FileInformation, FileInput } from 'leto-modelizer-plugin-core';
 import Branch from 'src/models/git/Branch';
@@ -85,7 +87,19 @@ jest.mock('browserfs', () => ({
     }),
     readFile: jest.fn((path, format, cb) => cb(null, 'test')),
     mkdir: jest.fn((path, cb) => cb(path !== 'projectId/goodPath' ? 'error' : undefined)),
-    writeFile: jest.fn((path, content, cb) => cb(path !== 'projectId/goodPath' ? 'error' : undefined)),
+    writeFile: jest.fn((path, content, _, cb) => cb(path !== 'projectId/goodPath' ? 'error' : undefined)),
+    rmdir: jest.fn((path, cb) => {
+      if (path === 'error') {
+        return cb(true);
+      }
+      return cb(false);
+    }),
+    unlink: jest.fn((path, cb) => {
+      if (path === 'error') {
+        return cb(true);
+      }
+      return cb(false);
+    }),
   })),
 }));
 
@@ -360,6 +374,26 @@ describe('Test composable: Project', () => {
         true,
       );
       expect(result).toEqual('pull');
+    });
+  });
+
+  describe('Test function: rmDir', () => {
+    it('should be a success on good path', async () => {
+      expect(await rmDir('ok')).toBeUndefined();
+    });
+
+    it('should be an error on bad path', async () => {
+      expect(await rmDir('error').catch((e) => e)).toBeDefined();
+    });
+  });
+
+  describe('Test function: rm', () => {
+    it('should be a success on good path', async () => {
+      expect(await rm('ok')).toBeUndefined();
+    });
+
+    it('should be an error on bad path', async () => {
+      expect(await rm('error').catch((e) => e)).toBeDefined();
     });
   });
 });

--- a/tests/unit/composables/QuasarFieldRule.spec.js
+++ b/tests/unit/composables/QuasarFieldRule.spec.js
@@ -2,6 +2,8 @@ import {
   notEmpty,
   isGitRepositoryUrl,
   isUniqueBranchName,
+  isValidFileLabel,
+  isUniqueFileLabel,
 } from 'src/composables/QuasarFieldRule';
 
 describe('Test composable: InputRule', () => {
@@ -49,6 +51,34 @@ describe('Test composable: InputRule', () => {
     it('should return string error message with duplicated branch', () => {
       const key = 'errors.git.branch.duplicate';
       expect(isUniqueBranchName(t, [{ name: 'test' }], 'test')).toEqual(key);
+    });
+  });
+
+  describe('Test function: isValidFileLabel', () => {
+    it('should return true on valid tree node label', () => {
+      expect(isValidFileLabel(t, 'folderName')).toBe(true);
+      expect(isValidFileLabel(t, 'app.tf')).toBe(true);
+      expect(isValidFileLabel(t, 'my-file.tf')).toBe(true);
+    });
+
+    it('should return string error message on invalid tree node label', () => {
+      const key = 'errors.invalid.fileExplorer.label';
+      expect(isValidFileLabel(t, '/folderName')).toEqual(key);
+      expect(isValidFileLabel(t, 'app/file.tf')).toEqual(key);
+      expect(isValidFileLabel(t, 'folder/app.tf')).toEqual(key);
+    });
+  });
+
+  describe('Test function: isUniqueFileLabel', () => {
+    it('should return true without duplicated node label', () => {
+      expect(isUniqueFileLabel(t, [], 'fileName')).toBe(true);
+      expect(isUniqueFileLabel(t, [{ label: 'app.tf' }], 'fileName')).toBe(true);
+      expect(isUniqueFileLabel(t, [{ label: 'folderA' }], 'folderB')).toBe(true);
+    });
+
+    it('should return string error message with duplicated node label', () => {
+      const key = 'errors.fileExplorer.label.duplicate';
+      expect(isUniqueFileLabel(t, [{ label: 'test' }], 'test')).toEqual(key);
     });
   });
 });

--- a/tests/unit/composables/events/FileEvent.spec.js
+++ b/tests/unit/composables/events/FileEvent.spec.js
@@ -15,4 +15,32 @@ describe('Test composable: FileEvent', () => {
       expect(FileEvent.SelectFileEvent).toEqual(new Subject());
     });
   });
+
+  describe('Test event: SelectNodeEvent', () => {
+    it('should export a Subject', () => {
+      expect(FileEvent.SelectNodeEvent).toBeDefined();
+      expect(FileEvent.SelectNodeEvent).toEqual(new Subject());
+    });
+  });
+
+  describe('Test event: CreateFileEvent', () => {
+    it('should export a Subject', () => {
+      expect(FileEvent.CreateFileEvent).toBeDefined();
+      expect(FileEvent.CreateFileEvent).toEqual(new Subject());
+    });
+  });
+
+  describe('Test event: DeleteFileEvent', () => {
+    it('should export a Subject', () => {
+      expect(FileEvent.DeleteFileEvent).toBeDefined();
+      expect(FileEvent.DeleteFileEvent).toEqual(new Subject());
+    });
+  });
+
+  describe('Test event: ExpandFolderEvent', () => {
+    it('should export a Subject', () => {
+      expect(FileEvent.ExpandFolderEvent).toBeDefined();
+      expect(FileEvent.ExpandFolderEvent).toEqual(new Subject());
+    });
+  });
 });


### PR DESCRIPTION
- Add menu action to create and delete a file/folder
- When a file is added, open a tab with empty content and expand the parent folder
- When a file is deleted, the dialog opens to confirm the deletion and then close the related tab
- When a non empty folder is deleted, the dialog contains a checkbox to force the user to confirm the deletion of the folder and all its content, also remove all tabs corresponding to the files that were inside this folder
- The name of the new file or folder should not contain any slash character, and should be unique (among all the parent's folder)