### PR TITLE
Bugfix : infinite loop onUpdated hook

### DIFF
--- a/src/components/ModelizerModelsView.vue
+++ b/src/components/ModelizerModelsView.vue
@@ -29,7 +29,7 @@
       >
         <router-link
           v-for="model in data.models"
-          :key="model.id"
+          :key="`${model.plugin}/${model.name}`"
           :to="{
             path: `/modelizer/${projectName}/model`,
             query: { path: `${model.plugin}/${model.name}` }}"
@@ -56,9 +56,10 @@
 import {
   onMounted,
   onUnmounted,
-  onUpdated,
   reactive,
   ref,
+  watch,
+  computed,
 } from 'vue';
 import { getAllModels } from 'src/composables/Project';
 import { getTemplatesByType } from 'src/composables/TemplateManager';
@@ -66,7 +67,9 @@ import ModelCard from 'src/components/card/ModelCard.vue';
 import DialogEvent from 'src/composables/events/DialogEvent';
 import UpdateModelEvent from 'src/composables/events/ModelEvent';
 import TemplateGrid from 'src/components/grid/TemplateGrid';
+import { useRoute } from 'vue-router';
 
+const route = useRoute();
 const props = defineProps({
   projectName: {
     type: String,
@@ -78,6 +81,7 @@ const data = reactive({
   models: [],
 });
 const templates = ref([]);
+const viewType = computed(() => route.params.viewType);
 
 let updateModelSubscription;
 
@@ -105,14 +109,16 @@ async function openNewModelTemplateDialog(template) {
   });
 }
 
+watch(() => viewType.value, () => {
+  if (viewType.value === 'models') {
+    updateModels();
+  }
+});
+
 onMounted(async () => {
   updateModels();
   templates.value = await getTemplatesByType('model');
   updateModelSubscription = UpdateModelEvent.subscribe(updateModels);
-});
-
-onUpdated(() => {
-  updateModels();
 });
 
 onUnmounted(() => {

--- a/tests/unit/components/ModelizerModelsView.spec.js
+++ b/tests/unit/components/ModelizerModelsView.spec.js
@@ -6,8 +6,13 @@ import Project from 'src/composables/Project';
 import { createI18n } from 'vue-i18n';
 import i18nConfiguration from 'src/i18n';
 import DialogEvent from 'src/composables/events/DialogEvent';
+import { useRoute } from 'vue-router';
 
 installQuasarPlugin();
+
+jest.mock('vue-router', () => ({
+  useRoute: jest.fn(),
+}));
 
 jest.mock('src/composables/events/ModelEvent', () => ({
   subscribe: jest.fn(),
@@ -29,6 +34,13 @@ describe('Test component: ModelizerModelsView', () => {
   beforeEach(() => {
     updateModelSubscribe = jest.fn();
     updateModelUnsubscribe = jest.fn();
+
+    useRoute.mockImplementation(() => ({
+      params: {
+        projectName: 'projectName',
+        viewType: 'models',
+      },
+    }));
 
     UpdateModelEvent.subscribe.mockImplementation(() => {
       updateModelSubscribe();
@@ -64,6 +76,12 @@ describe('Test component: ModelizerModelsView', () => {
   describe('Test props: projectName', () => {
     it('should match "projectName"', () => {
       expect(wrapper.vm.projectName).toEqual('projectName');
+    });
+  });
+
+  describe('Test computed: viewType', () => {
+    it('should match route.params.viewType', () => {
+      expect(wrapper.vm.viewType).toEqual('models');
     });
   });
 

--- a/tests/unit/components/ModelizerNavigationBar.spec.js
+++ b/tests/unit/components/ModelizerNavigationBar.spec.js
@@ -243,7 +243,7 @@ describe('Test component: ModelizerNavigationBar', () => {
   });
 
   describe('Test watcher: props.viewType', () => {
-    it('should be trigger when props.viewType is update with a different value', async () => {
+    it('should be triggered when props.viewType is updated with a different value', async () => {
       await wrapper.setProps({
         viewType: 'text',
         projectName: 'projectTest',


### PR DESCRIPTION
Replace `onUpdated` hook by watcher on `viewType` to call `updateModels` function