### PR TITLE
Bugfix : input focus when it's in error

### DIFF
--- a/src/components/drawer/ComponentDetailPanel.vue
+++ b/src/components/drawer/ComponentDetailPanel.vue
@@ -277,7 +277,7 @@ function updateAttribute(event) {
       selectedComponentAttributes.value[index] = event.attribute;
     }
   }
-  form.value.validate();
+  form.value.validate(false);
 }
 
 /**
@@ -295,7 +295,9 @@ function onViewSwitchUpdate(newViewType) {
  * @param {Object} event - Form event.
  */
 function onError(event) {
-  currentError.value = event.nativeEl.getAttribute('full-name');
+  if (event) {
+    currentError.value = event.nativeEl.getAttribute('full-name');
+  }
 }
 
 /**

--- a/src/components/inputs/NumberInput.vue
+++ b/src/components/inputs/NumberInput.vue
@@ -2,7 +2,7 @@
   <q-input
     type="number"
     ref="numberInput"
-    v-model="localValue"
+    v-model.number="localValue"
     :rules="[
       (value) => isRequired($t, value, attribute.definition?.required),
       (value) => isNumberTooSmall($t, value, attribute.definition?.rules.min),

--- a/src/components/menu/DefinitionMenu.vue
+++ b/src/components/menu/DefinitionMenu.vue
@@ -12,7 +12,10 @@
           <code>{{ definition.name }}</code>: {{ definition.type }}
         </div>
         <div class="q-mt-md" v-html="$sanitize(definition.description)"></div>
-        <div class="q-mt-lg text-right">
+        <div
+          v-if="definition.url"
+          class="q-mt-lg text-right"
+        >
           <a
             :href="$sanitize(definition.url)"
             target="_blank"

--- a/src/components/panel/AttributeSection.vue
+++ b/src/components/panel/AttributeSection.vue
@@ -36,7 +36,7 @@
         />
       </q-item-section>
       <q-item-section>
-        {{localAttribute.name}}
+        {{ localAttribute.definition?.displayName || localAttribute.name }}
       </q-item-section>
       <q-item-section v-if="hasError" side>
         <q-icon

--- a/tests/unit/components/drawer/ComponentDetailPanel.spec.js
+++ b/tests/unit/components/drawer/ComponentDetailPanel.spec.js
@@ -325,6 +325,12 @@ describe('test component: Plugin Component Detail Panel', () => {
 
       expect(wrapper.vm.currentError).toEqual('test');
     });
+
+    it('should not set currentError when onError param is falsy', () => {
+      wrapper.vm.onError(false);
+
+      expect(wrapper.vm.currentError).toBeNull();
+    });
   });
 
   describe('Test function: clearError', () => {


### PR DESCRIPTION
-  Make validate(false) to not focus any input in error
- Fix error in console when event in `onError` function is undefined
- Improve NumberInput v-model