### PR TITLE
Feature: Minor UI improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The file is now deleted when the last component of this file is deleted.
 * Fix console error on reloading Model view page.
 
+### Changed
+
+* Component list:
+  * Replace plugin name by "Components" in expansion item title
+  * Add margin before "Component filter" search icon
+  * Make all cards on the same line the same height
+  * Add margin between component icon and name
+* Others:
+  * Enlarge carousel image
+
 ## [1.0.0] - 2023/02/16
 
 ### Added

--- a/src/components/card/ComponentDefinitionCard.vue
+++ b/src/components/card/ComponentDefinitionCard.vue
@@ -39,7 +39,7 @@
         </q-icon>
       </q-item-section>
 
-      <q-item-section top>
+      <q-item-section top class="q-mt-xs">
         <q-item-label class="component-definition-type">
           {{ definition.displayName || definition.type.replaceAll('_', ' ') }}
         </q-item-label>

--- a/src/components/card/ComponentDefinitionCard.vue
+++ b/src/components/card/ComponentDefinitionCard.vue
@@ -2,7 +2,7 @@
   <q-card
     flat
     bordered
-    class="component-definition-card"
+    class="component-definition-card full-height"
     draggable="true"
     @dragstart="dragStartHandler"
     @dragend="dragEndHandler"
@@ -13,7 +13,7 @@
     <q-item
       clickable
       @click="onClickItem"
-      class="column q-pl-xs q-pr-xs items-center"
+      class="column q-pl-xs q-pr-xs items-center full-height"
     >
       <q-item-section
         v-if="definition.icon"
@@ -39,7 +39,7 @@
         </q-icon>
       </q-item-section>
 
-      <q-item-section>
+      <q-item-section top>
         <q-item-label class="component-definition-type">
           {{ definition.displayName || definition.type.replaceAll('_', ' ') }}
         </q-item-label>

--- a/src/components/dialog/DefaultDialog.vue
+++ b/src/components/dialog/DefaultDialog.vue
@@ -54,4 +54,8 @@ onUnmounted(() => {
     right: 2px;
     z-index: 10;
   }
+
+  .q-dialog__inner--minimized > div {
+      max-width: 680px;
+  }
 </style>

--- a/src/components/dialog/ImportModelTemplateDialog.vue
+++ b/src/components/dialog/ImportModelTemplateDialog.vue
@@ -83,7 +83,8 @@ onUnmounted(() => {
 <style scoped lang="scss">
 .carousel-img {
   cursor: zoom-in;
-  height: 100px;
+  max-height: 300px;
+  max-width: 520px;
 }
 </style>
 <style>

--- a/src/components/dialog/NewProjectTemplateDialog.vue
+++ b/src/components/dialog/NewProjectTemplateDialog.vue
@@ -21,7 +21,7 @@
           navigation
           padding
           arrows
-          height="200px"
+          min-height="200px"
           class="text-primary rounded-borders"
         >
           <q-carousel-slide
@@ -110,7 +110,8 @@ onUnmounted(() => {
 <style scoped lang="scss">
 .carousel-img {
   cursor: zoom-in;
-  height: 100px;
+  max-height: 300px;
+  max-width: 520px;
 }
 </style>
 

--- a/src/components/drawer/ComponentDefinitionsDrawer.vue
+++ b/src/components/drawer/ComponentDefinitionsDrawer.vue
@@ -39,7 +39,7 @@
         >
           <template v-slot:header>
             <q-item-section data-cy="plugin-definitions-title">
-              {{ plugin.data.name }}
+              {{ $t('page.modelizer.drawer.components.title') }}
             </q-item-section>
           </template>
           <q-scroll-area

--- a/src/components/drawer/ComponentDefinitionsDrawer.vue
+++ b/src/components/drawer/ComponentDefinitionsDrawer.vue
@@ -24,7 +24,10 @@
         :label="$t('page.modelizer.drawer.components.filterLabel')"
       >
         <template v-slot:prepend>
-          <q-icon name="fa-solid fa-magnifying-glass" />
+          <q-icon
+            name="fa-solid fa-magnifying-glass"
+            class="q-ml-md"
+          />
         </template>
       </q-input>
       <q-list text-white>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -232,6 +232,7 @@ export default {
       drawer: {
         components: {
           header: 'Components definitions',
+          title: 'Components',
           filterLabel: 'Component filter',
           button: {
             label: 'Back to models',


### PR DESCRIPTION
# Visual changelog

## ComponentDefinitionDrawer

<table>
<tr>
<th>Before</td>
<th>After</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/20184007/220353091-6482b709-2001-4a1b-8076-7b70c8599c30.png" /></td>
<td><img src="https://user-images.githubusercontent.com/20184007/220353767-710c476f-4301-40b4-86ed-c5c579c553f6.png" />
</td>
</tr>
</table>

* Replace plugin name by "Components" in expansion item title
* Add margin before "Component filter" search icon

## ComponentDefinitionCard

<table>
<tr>
<th>Before</td>
<th>After</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/20184007/220353257-fb0b1df6-1ecc-4345-950b-079b3db3c331.png" /></td>
<td><img src="https://user-images.githubusercontent.com/20184007/220353889-38fae40d-0e6d-4272-9362-a96b617b2b8c.png" /></td>
</tr>
</table>

* Make all cards on the same line the same height
* Add margin between component icon and name

## Others

<table>
<tr>
<th>Before</td>
<th>After</td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/20184007/220353515-cfa1008a-1a50-4ed2-85c1-7938bf9f7452.png" /></td>
<td><img src="https://user-images.githubusercontent.com/20184007/220354114-a8d10e62-4c0a-450b-88fe-10ab1235f901.png" /></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/20184007/220356821-ad1c0b7b-b6ee-47d8-b417-a37e4cd2c077.png" /></td>
<td><img src="https://user-images.githubusercontent.com/20184007/220356526-c9b3d55c-dcdc-4d18-b779-245ed00d862e.png" /></td>
</tr>
</table>

* Enlarge carousel image