### PR TITLE
Improvement : updating data-cy for e2e tests

### DIFF
--- a/cypress/e2e/HomePage/create.project.feature
+++ b/cypress/e2e/HomePage/create.project.feature
@@ -4,7 +4,7 @@ Feature: Test homepage: project creation
     Given I clear cache
     And  I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
 

--- a/cypress/e2e/HomePage/create.project.feature
+++ b/cypress/e2e/HomePage/create.project.feature
@@ -5,8 +5,8 @@ Feature: Test homepage: project creation
     And  I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
 
   Scenario: Create project should redirect to project model view page
     Then I expect current url is "modelizer/projectName/models"

--- a/cypress/e2e/HomePage/create.project.feature
+++ b/cypress/e2e/HomePage/create.project.feature
@@ -2,11 +2,11 @@ Feature: Test homepage: project creation
 
   Background:
     Given I clear cache
-    And I visit the "/"
+    And  I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
 
   Scenario: Create project should redirect to project model view page
     Then I expect current url is "modelizer/projectName/models"

--- a/cypress/e2e/HomePage/create.project.feature
+++ b/cypress/e2e/HomePage/create.project.feature
@@ -2,18 +2,18 @@ Feature: Test homepage: project creation
 
   Background:
     Given I clear cache
-    And  I visit the "/"
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
 
   Scenario: Create project should redirect to project model view page
-    Then I expect current url is "modelizer/projectName/models"
+    Then I expect current url is 'modelizer/projectName/models'
 
   Scenario: Create project should send positive notification
-    Then I expect "positive" toast to appear with text "Project has been created 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been created 🥳!'
 
   Scenario: Create project should save it in browser cache
-    Then I expect current url is "modelizer/projectName/models"
-    And  I expect localstorage field "projects" is '{"projectName":{"id":"projectName"}}'
+    Then I expect current url is 'modelizer/projectName/models'
+    And  I expect localstorage field 'projects' is '{"projectName":{"id":"projectName"}}'

--- a/cypress/e2e/HomePage/create.project.feature
+++ b/cypress/e2e/HomePage/create.project.feature
@@ -4,9 +4,9 @@ Feature: Test homepage: project creation
     Given I clear cache
     And  I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
 
   Scenario: Create project should redirect to project model view page
     Then I expect current url is "modelizer/projectName/models"

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -6,7 +6,7 @@ Feature: Test homepage: project deletion
     And  I visit the "/"
 
   Scenario: Delete existing project
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "modelizer/projectName/model"
@@ -23,7 +23,7 @@ Feature: Test homepage: project deletion
 
   Scenario: Delete project should remove it from database
     Given I set context field "projectName" with "leto-modelizer-project-test"
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
@@ -59,7 +59,7 @@ Feature: Test homepage: project deletion
     And  I expect '[data-cy="delete-project-form"]' is closed
     And  I expect '[data-cy="project-card_{{ projectName }}"]' not exists
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -6,9 +6,9 @@ Feature: Test homepage: project deletion
     And  I visit the "/"
 
   Scenario: Delete existing project
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -41,7 +41,7 @@ Feature: Test homepage: project deletion
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -2,37 +2,38 @@ Feature: Test homepage: project deletion
 
   Background:
     Given I clear cache
-    And  I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I visit the '/'
 
   Scenario: Delete existing project
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "modelizer/projectName/model"
+    Then I expect current url is 'modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
-    Then I expect current url is "/"
+    Then I expect current url is '/'
 
     When I click on '[data-cy="project-card_projectName"] [data-cy="delete-button"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been deleted 😥"
+    Then I expect 'positive' toast to appear with text 'Project has been deleted 😥'
     And  I expect '[data-cy="delete-project-form"]' is closed
     And  I expect '[data-cy="project-card_projectName"]' not exists
 
   Scenario: Delete project should remove it from database
-    Given I set context field "projectName" with "leto-modelizer-project-test"
-    When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
+    Given I set context field 'projectName' with 'leto-modelizer-project-test'
 
-    When I visit the "/#/modelizer/{{ projectName }}/text"
+    When I click on '[data-cy="import-project-button"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+
+    When I visit the '/#/modelizer/{{ projectName }}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 1 second
 
@@ -45,30 +46,30 @@ Feature: Test homepage: project deletion
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file_branch.txt.js"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
-    Then I expect current url is "/"
+    Then I expect current url is '/'
 
     When I click on '[data-cy="project-card_{{ projectName }}"] [data-cy="delete-button"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been deleted 😥"
+    Then I expect 'positive' toast to appear with text 'Project has been deleted 😥'
     And  I expect '[data-cy="delete-project-form"]' is closed
     And  I expect '[data-cy="project-card_{{ projectName }}"]' not exists
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}\"]' exists
     And  I wait 1 second
 

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -33,12 +33,12 @@ Feature: Test homepage: project deletion
     And  I expect current url is "modelizer/{{ projectName }}/model"
 
     When I visit the "/#/modelizer/{{ projectName }}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 1 second
 
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -47,7 +47,7 @@ Feature: Test homepage: project deletion
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
+    And  I expect '[data-cy="file_branch.txt.js"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
@@ -69,8 +69,8 @@ Feature: Test homepage: project deletion
     And  I expect current url is "modelizer/{{ projectName }}/model"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}\"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}\"]' exists
     And  I wait 1 second
 
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    Then I expect '[data-cy="file-explorer-branch.txt"]' exists
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer"] [data-cy="file_branch.txt"]' exists

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -11,7 +11,7 @@ Feature: Test homepage: project deletion
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "modelizer/projectName/model"
 
-    When I click on '[data-cy="app-logo-link"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
 
     When I click on '[data-cy="delete-project-projectName"]'
@@ -49,7 +49,7 @@ Feature: Test homepage: project deletion
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
 
-    When I click on '[data-cy="app-logo-link"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
 
     When I click on '[data-cy="delete-project-{{ projectName }}"]'

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -6,71 +6,71 @@ Feature: Test homepage: project deletion
     And  I visit the "/"
 
   Scenario: Delete existing project
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "modelizer/projectName/model"
 
-    When I click on "[data-cy=\"app-logo-link\"]"
+    When I click on '[data-cy="app-logo-link"]'
     Then I expect current url is "/"
 
-    When I click on "[data-cy=\"delete-project-projectName\"]"
-    And  I click on "[data-cy=\"delete-project-form\"] [data-cy=\"confirm-delete-project-checkbox\"]"
-    And  I click on "[data-cy=\"delete-project-form\"] [data-cy=\"delete-project-form-submit\"]"
+    When I click on '[data-cy="delete-project-projectName"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-project-checkbox"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="delete-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
-    And  I expect "[data-cy=\"delete-project-form\"]" is closed
-    And  I expect "[data-cy=\"project-card\"]" not exists
+    And  I expect '[data-cy="delete-project-form"]' is closed
+    And  I expect '[data-cy="project-card"]' not exists
 
   Scenario: Delete project should remove it from database
     Given I set context field "projectName" with "leto-modelizer-project-test"
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
 
     When I visit the "/#/modelizer/{{ projectName }}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 1 second
 
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-branch.txt.js\"]" not exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
 
-    When I click on "[data-cy=\"app-logo-link\"]"
+    When I click on '[data-cy="app-logo-link"]'
     Then I expect current url is "/"
 
-    When I click on "[data-cy=\"delete-project-{{ projectName }}\"]"
-    And  I click on "[data-cy=\"delete-project-form\"] [data-cy=\"confirm-delete-project-checkbox\"]"
-    And  I click on "[data-cy=\"delete-project-form\"] [data-cy=\"delete-project-form-submit\"]"
+    When I click on '[data-cy="delete-project-{{ projectName }}"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-project-checkbox"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="delete-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
-    And  I expect "[data-cy=\"delete-project-form\"]" is closed
-    And  I expect "[data-cy=\"project-card\"]" not exists
+    And  I expect '[data-cy="delete-project-form"]' is closed
+    And  I expect '[data-cy="project-card"]' not exists
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}\"]' exists
     And  I wait 1 second
 
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    Then I expect "[data-cy=\"file-explorer-branch.txt\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer-branch.txt"]' exists

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -14,12 +14,12 @@ Feature: Test homepage: project deletion
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
 
-    When I click on '[data-cy="delete-project-projectName"]'
+    When I click on '[data-cy="project-card_projectName"] [data-cy="delete-button"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
     And  I expect '[data-cy="delete-project-form"]' is closed
-    And  I expect '[data-cy="project-card"]' not exists
+    And  I expect '[data-cy="project-card_projectName"]' not exists
 
   Scenario: Delete project should remove it from database
     Given I set context field "projectName" with "leto-modelizer-project-test"
@@ -52,12 +52,12 @@ Feature: Test homepage: project deletion
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
 
-    When I click on '[data-cy="delete-project-{{ projectName }}"]'
+    When I click on '[data-cy="project-card_{{ projectName }}"] [data-cy="delete-button"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
     And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
     And  I expect '[data-cy="delete-project-form"]' is closed
-    And  I expect '[data-cy="project-card"]' not exists
+    And  I expect '[data-cy="project-card_{{ projectName }}"]' not exists
 
     When I click on '[data-cy="import-project"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"

--- a/cypress/e2e/HomePage/delete.project.feature
+++ b/cypress/e2e/HomePage/delete.project.feature
@@ -7,16 +7,16 @@ Feature: Test homepage: project deletion
 
   Scenario: Delete existing project
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
 
     When I click on '[data-cy="delete-project-projectName"]'
-    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-project-checkbox"]'
-    And  I click on '[data-cy="delete-project-form"] [data-cy="delete-project-form-submit"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
     And  I expect '[data-cy="delete-project-form"]' is closed
     And  I expect '[data-cy="project-card"]' not exists
@@ -24,10 +24,10 @@ Feature: Test homepage: project deletion
   Scenario: Delete project should remove it from database
     Given I set context field "projectName" with "leto-modelizer-project-test"
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
@@ -44,7 +44,7 @@ Feature: Test homepage: project deletion
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
@@ -53,17 +53,17 @@ Feature: Test homepage: project deletion
     Then I expect current url is "/"
 
     When I click on '[data-cy="delete-project-{{ projectName }}"]'
-    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-project-checkbox"]'
-    And  I click on '[data-cy="delete-project-form"] [data-cy="delete-project-form-submit"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="confirm-delete-checkbox"]'
+    And  I click on '[data-cy="delete-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been deleted 😥"
     And  I expect '[data-cy="delete-project-form"]' is closed
     And  I expect '[data-cy="project-card"]' not exists
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"

--- a/cypress/e2e/HomePage/import.project.feature
+++ b/cypress/e2e/HomePage/import.project.feature
@@ -2,16 +2,16 @@ Feature: Test homepage: project import
 
   Scenario: Import project should redirect to project model view page
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And  I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I set context field "projectName" with "leto-modelizer-project-test"
+    And  I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
-    And I expect current url is "modelizer/{{ projectName }}/model"
-    And I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I expect current url is "modelizer/{{ projectName }}/model"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"

--- a/cypress/e2e/HomePage/import.project.feature
+++ b/cypress/e2e/HomePage/import.project.feature
@@ -2,16 +2,16 @@ Feature: Test homepage: project import
 
   Scenario: Import project should redirect to project model view page
     Given I clear cache
-    And  I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I set context field "projectName" with "leto-modelizer-project-test"
-    And  I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is 'modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'

--- a/cypress/e2e/HomePage/import.project.feature
+++ b/cypress/e2e/HomePage/import.project.feature
@@ -6,7 +6,7 @@ Feature: Test homepage: project import
     And  I set context field "projectName" with "leto-modelizer-project-test"
     And  I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/HomePage/import.project.feature
+++ b/cypress/e2e/HomePage/import.project.feature
@@ -7,10 +7,10 @@ Feature: Test homepage: project import
     And  I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -8,7 +8,7 @@ Feature: Test homepage: open project
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     And  I expect current url is "modelizer/projectName/model"
 
-    When I click on '[data-cy="app-logo-link"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
     And  I expect '[data-cy="project-card-projectName"]' exists
     And  I expect '[data-cy="project-card-projectName"] [data-cy="project-card-title"]' is "projectName"

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -2,16 +2,16 @@ Feature: Test homepage: open project
 
   Scenario: Open existing project
     Given I clear cache
-    And I visit the "/"
-    And I click on "[data-cy=\"new-project\"]"
-    And I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
-    And I expect current url is "modelizer/projectName/model"
+    And  I visit the "/"
+    And  I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I expect current url is "modelizer/projectName/model"
 
-    When I click on "[data-cy=\"app-logo-link\"]"
+    When I click on '[data-cy="app-logo-link"]'
     Then I expect current url is "/"
-    And I expect "[data-cy=\"project-card-projectName\"]" exists
-    And I expect "[data-cy=\"project-card-projectName\"] [data-cy=\"project-card-title\"]" is "projectName"
+    And  I expect '[data-cy="project-card-projectName"]' exists
+    And  I expect '[data-cy="project-card-projectName"] [data-cy="project-card-title"]' is "projectName"
 
-    When I click on "[data-cy=\"project-card-projectName\"]"
+    When I click on '[data-cy="project-card-projectName"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -3,9 +3,9 @@ Feature: Test homepage: open project
   Scenario: Open existing project
     Given I clear cache
     And  I visit the "/"
-    And  I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    And  I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     And  I expect current url is "modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -3,7 +3,7 @@ Feature: Test homepage: open project
   Scenario: Open existing project
     Given I clear cache
     And  I visit the "/"
-    And  I click on '[data-cy="new-project"]'
+    And  I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     And  I expect current url is "modelizer/projectName/model"

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -4,8 +4,8 @@ Feature: Test homepage: open project
     Given I clear cache
     And  I visit the "/"
     And  I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     And  I expect current url is "modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -2,16 +2,17 @@ Feature: Test homepage: open project
 
   Scenario: Open existing project
     Given I clear cache
-    And  I visit the "/"
+
+    When I visit the '/'
     And  I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    And  I expect current url is "modelizer/projectName/model"
+    Then I expect current url is 'modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
-    Then I expect current url is "/"
+    Then I expect current url is '/'
     And  I expect '[data-cy="project-card_projectName"]' exists
-    And  I expect '[data-cy="project-card_projectName"] [data-cy="title-container"]' is "projectName"
+    And  I expect '[data-cy="project-card_projectName"] [data-cy="title-container"]' is 'projectName'
 
     When I click on '[data-cy="project-card_projectName"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'

--- a/cypress/e2e/HomePage/open.project.feature
+++ b/cypress/e2e/HomePage/open.project.feature
@@ -10,8 +10,8 @@ Feature: Test homepage: open project
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
-    And  I expect '[data-cy="project-card-projectName"]' exists
-    And  I expect '[data-cy="project-card-projectName"] [data-cy="project-card-title"]' is "projectName"
+    And  I expect '[data-cy="project-card_projectName"]' exists
+    And  I expect '[data-cy="project-card_projectName"] [data-cy="title-container"]' is "projectName"
 
-    When I click on '[data-cy="project-card-projectName"]'
+    When I click on '[data-cy="project-card_projectName"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -5,9 +5,9 @@ Feature: Test git add remote repository dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -5,7 +5,7 @@ Feature: Test git add remote repository dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -13,8 +13,8 @@ Feature: Test git add remote repository dialog
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Set valid git remote repository in the project should send positive toast
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
@@ -23,26 +23,26 @@ Feature: Test git add remote repository dialog
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
   Scenario: Set bad repository url should display an error
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     And  I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "bad"
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Invalid repository url"
 
   Scenario: Set empty repository should display an error
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
     And  I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Please type something"
 
   Scenario: After setting a valid git remote repository, only git authentication menu should be displayed
-    When I click on '[data-cy="project-settings"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
     Then I expect '[data-cy="project-settings-menu"]' exists
-    And  I expect '[data-cy="git-settings-menu-GitAddRemote"]' exists
-    And  I expect '[data-cy="git-settings-menu-GitAuthentication"]' exists
+    And  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]' exists
+    And  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]' exists
 
-    When I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
     And  I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
 
@@ -51,16 +51,16 @@ Feature: Test git add remote repository dialog
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
-    When I click on '[data-cy="project-settings"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
     Then I expect '[data-cy="project-settings-menu"]' exists
-    And  I expect '[data-cy="git-settings-menu-GitAuthentication"]' exists
-    But  I expect '[data-cy="git-settings-menu-GitAddRemote"]' not exists
+    And  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]' exists
+    But  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]' not exists
 
   Scenario: Set git add remote repository should bring up the "Upload to git" button.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -2,39 +2,39 @@ Feature: Test git add remote repository dialog
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-    When I visit the "/#/modelizer/projectName/text"
+    When I visit the '/#/modelizer/projectName/text'
 
   Scenario: Set valid git remote repository in the project should send positive toast
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
   Scenario: Set bad repository url should display an error
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
-    And  I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "bad"
+    And  I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'bad'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Invalid repository url"
+    Then I expect '[data-cy="git-add-remote-form"] [role="alert"]' is 'Invalid repository url'
 
   Scenario: Set empty repository should display an error
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
-    And  I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Please type something"
+    Then I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ''
+    And  I expect '[data-cy="git-add-remote-form"] [role="alert"]' is 'Please type something'
 
   Scenario: After setting a valid git remote repository, only git authentication menu should be displayed
     When I click on '[data-cy="modelizer-settings-button"]'
@@ -44,11 +44,11 @@ Feature: Test git add remote repository dialog
 
     When I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
-    And  I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
+    And  I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ''
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
     When I click on '[data-cy="modelizer-settings-button"]'
@@ -56,15 +56,15 @@ Feature: Test git add remote repository dialog
     And  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]' exists
     But  I expect '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]' not exists
 
-  Scenario: Set git add remote repository should bring up the "Upload to git" button.
+  Scenario: Set git add remote repository should bring up the 'Upload to git' button.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -5,66 +5,66 @@ Feature: Test git add remote repository dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Set valid git remote repository in the project should send positive toast
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
 
   Scenario: Set bad repository url should display an error
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    And  I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "bad"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"] [role=\"alert\"]" is "Invalid repository url"
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    And  I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "bad"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Invalid repository url"
 
   Scenario: Set empty repository should display an error
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect field "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" is ""
-    And  I expect "[data-cy=\"git-add-remote-form\"] [role=\"alert\"]" is "Please type something"
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    Then I expect field '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' is ""
+    And  I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Please type something"
 
   Scenario: After setting a valid git remote repository, only git authentication menu should be displayed
-    When I click on "[data-cy=\"project-settings\"]"
-    Then I expect "[data-cy=\"project-settings-menu\"]" exists
-    And  I expect "[data-cy=\"git-settings-menu-GitAddRemote\"]" exists
-    And  I expect "[data-cy=\"git-settings-menu-GitAuthentication\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    Then I expect '[data-cy="project-settings-menu"]' exists
+    And  I expect '[data-cy="git-settings-menu-GitAddRemote"]' exists
+    And  I expect '[data-cy="git-settings-menu-GitAuthentication"]' exists
 
-    When I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
-    And  I expect field "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" is ""
+    When I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
+    And  I expect field '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' is ""
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
 
-    When I click on "[data-cy=\"project-settings\"]"
-    Then I expect "[data-cy=\"project-settings-menu\"]" exists
-    And  I expect "[data-cy=\"git-settings-menu-GitAuthentication\"]" exists
-    But  I expect "[data-cy=\"git-settings-menu-GitAddRemote\"]" not exists
+    When I click on '[data-cy="project-settings"]'
+    Then I expect '[data-cy="project-settings-menu"]' exists
+    And  I expect '[data-cy="git-settings-menu-GitAuthentication"]' exists
+    But  I expect '[data-cy="git-settings-menu-GitAddRemote"]' not exists
 
   Scenario: Set git add remote repository should bring up the "Upload to git" button.
-    Given I expect "[data-cy=\"upload-to-git-button\"]" not exists
+    Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" exists
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' exists

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.add.remote.feature
@@ -6,8 +6,8 @@ Feature: Test git add remote repository dialog
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
@@ -17,23 +17,23 @@ Feature: Test git add remote repository dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
   Scenario: Set bad repository url should display an error
     When I click on '[data-cy="project-settings"]'
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
-    And  I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "bad"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    And  I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "bad"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Invalid repository url"
 
   Scenario: Set empty repository should display an error
     When I click on '[data-cy="project-settings"]'
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
-    Then I expect field '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' is ""
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
+    Then I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
     And  I expect '[data-cy="git-add-remote-form"] [role="alert"]' is "Please type something"
 
   Scenario: After setting a valid git remote repository, only git authentication menu should be displayed
@@ -44,10 +44,10 @@ Feature: Test git add remote repository dialog
 
     When I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
-    And  I expect field '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' is ""
+    And  I expect field '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' is ""
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
 
@@ -63,8 +63,8 @@ Feature: Test git add remote repository dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -5,9 +5,9 @@ Feature: Test git authentication dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -2,25 +2,25 @@ Feature: Test git authentication dialog
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-    When I visit the "/#/modelizer/projectName/text"
+    When I visit the '/#/modelizer/projectName/text'
 
   Scenario: Set git authentication in the project should send positive toast
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Git authentication updated &#129395;!'
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
   Scenario: Set git authentication then set git add remote repository should keep saved authentication values in each corresponding fields
@@ -28,36 +28,36 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Git authentication updated &#129395;!'
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
-    Then I expect field '[data-cy="git-authentication-form"] [data-cy="username-input"]' is "test"
-    And  I expect field '[data-cy="git-authentication-form"] [data-cy="token-input"]' is "test"
+    Then I expect field '[data-cy="git-authentication-form"] [data-cy="username-input"]' is 'test'
+    And  I expect field '[data-cy="git-authentication-form"] [data-cy="token-input"]' is 'test'
 
-  Scenario: Set git add remote repository then set valid git authentication should enable the "Upload to git" button.
+  Scenario: Set git add remote repository then set valid git authentication should enable the 'Upload to git' button.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
@@ -66,23 +66,23 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Git authentication updated &#129395;!'
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be enabled
   
-  Scenario: Set git add remote repository then set empty git username should keep the "Upload to git" button disabled.
+  Scenario: Set git add remote repository then set empty git username should keep the 'Upload to git' button disabled.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
@@ -91,22 +91,22 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Git authentication updated &#129395;!'
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-  Scenario: Set git add remote repository then set empty git token should keep the "Upload to git" button disabled.
+  Scenario: Set git add remote repository then set empty git token should keep the 'Upload to git' button disabled.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text 'https://github.com/ditrit/leto-modelizer-project-test'
     And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
+    Then I expect 'positive' toast to appear with text 'We have access to your repository 🥳!'
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
@@ -115,8 +115,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "username"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text 'username'
     And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Git authentication updated &#129395;!'
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -5,7 +5,7 @@ Feature: Test git authentication dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -5,118 +5,118 @@ Feature: Test git authentication dialog
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Set git authentication in the project should send positive toast
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect "[data-cy=\"git-authentication-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
-    And  I expect "[data-cy=\"git-authentication-form\"]" is closed
+    And  I expect '[data-cy="git-authentication-form"]' is closed
 
   Scenario: Set git authentication then set git add remote repository should keep saved authentication values in each corresponding fields
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect "[data-cy=\"git-authentication-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
-    And  I expect "[data-cy=\"git-authentication-form\"]" is closed
+    And  I expect '[data-cy="git-authentication-form"]' is closed
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
     
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect field "[data-cy=\"git-authentication-form\"] [data-cy=\"git-username-input\"]" is "test"
-    And  I expect field "[data-cy=\"git-authentication-form\"] [data-cy=\"git-token-input\"]" is "test"
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect field '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' is "test"
+    And  I expect field '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' is "test"
 
   Scenario: Set git add remote repository then set valid git authentication should enable the "Upload to git" button.
-    Given I expect "[data-cy=\"upload-to-git-button\"]" not exists
+    Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" exists
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be disabled
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' exists
+    And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect "[data-cy=\"git-authentication-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
-    And  I expect "[data-cy=\"git-authentication-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be enabled
+    And  I expect '[data-cy="git-authentication-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' to be enabled
   
   Scenario: Set git add remote repository then set empty git username should keep the "Upload to git" button disabled.
-    Given I expect "[data-cy=\"upload-to-git-button\"]" not exists
+    Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" exists
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be disabled
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' exists
+    And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect "[data-cy=\"git-authentication-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
-    And  I expect "[data-cy=\"git-authentication-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be disabled
+    And  I expect '[data-cy="git-authentication-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
   Scenario: Set git add remote repository then set empty git token should keep the "Upload to git" button disabled.
-    Given I expect "[data-cy=\"upload-to-git-button\"]" not exists
+    Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAddRemote\"]"
-    Then I expect "[data-cy=\"git-add-remote-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-repository-input\"]" text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on "[data-cy=\"git-add-remote-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
-    And  I expect "[data-cy=\"git-add-remote-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" exists
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be disabled
+    And  I expect '[data-cy="git-add-remote-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' exists
+    And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And  I click on "[data-cy=\"git-settings-menu-GitAuthentication\"]"
-    Then I expect "[data-cy=\"git-authentication-form\"]" exists
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-username-input\"]" text "username"
-    And  I click on "[data-cy=\"git-authentication-form\"] [data-cy=\"git-form-submit\"]"
+    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "username"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
-    And  I expect "[data-cy=\"git-authentication-form\"]" is closed
-    And  I expect "[data-cy=\"upload-to-git-button\"]" to be disabled
+    And  I expect '[data-cy="git-authentication-form"]' is closed
+    And  I expect '[data-cy="upload-to-git-button"]' to be disabled

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -6,8 +6,8 @@ Feature: Test git authentication dialog
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
@@ -17,9 +17,9 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
@@ -28,9 +28,9 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
@@ -38,15 +38,15 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     
     When I click on '[data-cy="project-settings"]'
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
-    Then I expect field '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' is "test"
-    And  I expect field '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' is "test"
+    Then I expect field '[data-cy="git-authentication-form"] [data-cy="username-input"]' is "test"
+    And  I expect field '[data-cy="git-authentication-form"] [data-cy="token-input"]' is "test"
 
   Scenario: Set git add remote repository then set valid git authentication should enable the "Upload to git" button.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
@@ -55,8 +55,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
@@ -66,9 +66,9 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be enabled
@@ -80,8 +80,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
@@ -91,8 +91,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
@@ -104,8 +104,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
-    When I set on '[data-cy="git-add-remote-form"] [data-cy="git-repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I click on '[data-cy="git-add-remote-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
+    And  I click on '[data-cy="git-add-remote-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' exists
@@ -115,8 +115,8 @@ Feature: Test git authentication dialog
     And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
-    When I set on '[data-cy="git-authentication-form"] [data-cy="git-username-input"]' text "username"
-    And  I click on '[data-cy="git-authentication-form"] [data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "username"
+    And  I click on '[data-cy="git-authentication-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled

--- a/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
+++ b/cypress/e2e/ModelizerPage/Common/Settings/git.authentication.feature
@@ -13,8 +13,8 @@ Feature: Test git authentication dialog
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Set git authentication in the project should send positive toast
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
     When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
@@ -24,8 +24,8 @@ Feature: Test git authentication dialog
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
   Scenario: Set git authentication then set git add remote repository should keep saved authentication values in each corresponding fields
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
     When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
@@ -34,8 +34,8 @@ Feature: Test git authentication dialog
     Then I expect "positive" toast to appear with text "Git authentication updated &#129395;!"
     And  I expect '[data-cy="git-authentication-form"]' is closed
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
@@ -43,16 +43,16 @@ Feature: Test git authentication dialog
     Then I expect "positive" toast to appear with text "We have access to your repository 🥳!"
     And  I expect '[data-cy="git-add-remote-form"]' is closed
     
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect field '[data-cy="git-authentication-form"] [data-cy="username-input"]' is "test"
     And  I expect field '[data-cy="git-authentication-form"] [data-cy="token-input"]' is "test"
 
   Scenario: Set git add remote repository then set valid git authentication should enable the "Upload to git" button.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
@@ -62,8 +62,8 @@ Feature: Test git authentication dialog
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
     When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "test"
@@ -76,8 +76,8 @@ Feature: Test git authentication dialog
   Scenario: Set git add remote repository then set empty git username should keep the "Upload to git" button disabled.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
@@ -87,8 +87,8 @@ Feature: Test git authentication dialog
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
     When I set on '[data-cy="git-authentication-form"] [data-cy="token-input"]' text "test"
@@ -100,8 +100,8 @@ Feature: Test git authentication dialog
   Scenario: Set git add remote repository then set empty git token should keep the "Upload to git" button disabled.
     Given I expect '[data-cy="upload-to-git-button"]' not exists
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAddRemote"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAddRemote"]'
     Then I expect '[data-cy="git-add-remote-form"]' exists
 
     When I set on '[data-cy="git-add-remote-form"] [data-cy="repository-input"]' text "https://github.com/ditrit/leto-modelizer-project-test"
@@ -111,8 +111,8 @@ Feature: Test git authentication dialog
     And  I expect '[data-cy="upload-to-git-button"]' exists
     And  I expect '[data-cy="upload-to-git-button"]' to be disabled
 
-    When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-settings-menu-GitAuthentication"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
+    And  I click on '[data-cy="project-settings-menu"] [data-cy="item_GitAuthentication"]'
     Then I expect '[data-cy="git-authentication-form"]' exists
 
     When I set on '[data-cy="git-authentication-form"] [data-cy="username-input"]' text "username"

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -6,8 +6,8 @@ Feature: Test modelizer page: default functionalities
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -2,13 +2,13 @@ Feature: Test modelizer page: default functionalities
 
   Scenario: Clicking on application logo should redirect to homepage
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
-    Then I expect current url is "/"
+    Then I expect current url is '/'

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -5,10 +5,10 @@ Feature: Test modelizer page: default functionalities
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on "[data-cy=\"app-logo-link\"]"
+    When I click on '[data-cy="app-logo-link"]'
     Then I expect current url is "/"

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -10,5 +10,5 @@ Feature: Test modelizer page: default functionalities
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on '[data-cy="app-logo-link"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -5,9 +5,9 @@ Feature: Test modelizer page: default functionalities
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/ModelizerPage/Common/default.feature
+++ b/cypress/e2e/ModelizerPage/Common/default.feature
@@ -5,7 +5,7 @@ Feature: Test modelizer page: default functionalities
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -5,9 +5,9 @@ Feature: Test modelizer page: switch view (text/model)
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Default modelizer page mode should be "model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -6,8 +6,8 @@ Feature: Test modelizer page: switch view (text/model)
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Default modelizer page mode should be "model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -2,28 +2,28 @@ Feature: Test modelizer page: switch view (text/model)
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-  Scenario: Default modelizer page mode should be "model"
-    When I visit the "/"
-    And  I visit the "/#/modelizer/projectName"
-    Then I expect current url is "/modelizer/projectName/model"
+  Scenario: Default modelizer page mode should be 'model'
+    When I visit the '/'
+    And  I visit the '/#/modelizer/projectName'
+    Then I expect current url is '/modelizer/projectName/model'
 
   @skip
   # TODO: update/fix test
-  Scenario: Modelizer "model" page should load the correct content
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+  Scenario: Modelizer 'model' page should load the correct content
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
-  Scenario: Modelizer "text" page should load the correct content
-    When I visit the "/#/modelizer/projectName/text"
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+  Scenario: Modelizer 'text' page should load the correct content
+    When I visit the '/#/modelizer/projectName/text'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
@@ -32,12 +32,12 @@ Feature: Test modelizer page: switch view (text/model)
   # TODO: update/fix test
   Scenario: Clicking on switch should change page content
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
-    And  I expect current url is "/projectName/text"
+    And  I expect current url is '/projectName/text'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
-    And  I expect current url is "/projectName/model"
+    And  I expect current url is '/projectName/model'

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -19,7 +19,7 @@ Feature: Test modelizer page: switch view (text/model)
   # TODO: update/fix test
   Scenario: Modelizer "model" page should load the correct content
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
   Scenario: Modelizer "text" page should load the correct content
     When I visit the "/#/modelizer/projectName/text"
@@ -39,5 +39,5 @@ Feature: Test modelizer page: switch view (text/model)
     And  I expect current url is "/projectName/text"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect current url is "/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -5,9 +5,9 @@ Feature: Test modelizer page: switch view (text/model)
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Default modelizer page mode should be "model"
@@ -18,26 +18,26 @@ Feature: Test modelizer page: switch view (text/model)
   @skip
   # TODO: update/fix test
   Scenario: Modelizer "model" page should load the correct content
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
   Scenario: Modelizer "text" page should load the correct content
     When I visit the "/#/modelizer/projectName/text"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-explorer\"]" exists
-    And  I expect "[data-cy=\"file-tabs\"]" exists
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-explorer"]' exists
+    And  I expect '[data-cy="file-tabs"]' exists
 
   @skip
   # TODO: update/fix test
   Scenario: Clicking on switch should change page content
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-explorer\"]" exists
-    And  I expect "[data-cy=\"file-tabs\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-explorer"]' exists
+    And  I expect '[data-cy="file-tabs"]' exists
     And  I expect current url is "/projectName/text"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect current url is "/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -18,12 +18,12 @@ Feature: Test modelizer page: switch view (text/model)
   @skip
   # TODO: update/fix test
   Scenario: Modelizer "model" page should load the correct content
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
   Scenario: Modelizer "text" page should load the correct content
     When I visit the "/#/modelizer/projectName/text"
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
@@ -31,13 +31,13 @@ Feature: Test modelizer page: switch view (text/model)
   @skip
   # TODO: update/fix test
   Scenario: Clicking on switch should change page content
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
     And  I expect current url is "/projectName/text"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect current url is "/projectName/model"

--- a/cypress/e2e/ModelizerPage/Common/switch.view.feature
+++ b/cypress/e2e/ModelizerPage/Common/switch.view.feature
@@ -5,7 +5,7 @@ Feature: Test modelizer page: switch view (text/model)
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -11,10 +11,10 @@ Feature: Test modelizer model view: add plugin component
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
 
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario Outline: Click on the <element> component should display it on the page

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -7,22 +7,22 @@ Feature: Test modelizer model view: add plugin component
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"] [data-cy=\"plugin-definitions-title\"]" is "terrator-plugin"
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
 
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario Outline: Click on the <element> component should display it on the page
-    Then I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>\"]" not exists
+    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' not exists
 
-    When I click on "[data-cy=\"component-definition-<element>\"]"
-    Then I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>\"]" exists
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>\"]" appear 1 time on screen
+    When I click on '[data-cy="component-definition-<element>"]'
+    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' exists
+    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' appear 1 time on screen
 
     Examples:
       | element               |
@@ -45,11 +45,11 @@ Feature: Test modelizer model view: add plugin component
       | aws_key_pair          |
 
   Scenario Outline: Dragging the <element> component should display it on the page
-    Then I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>_\"]" not exists
+    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' not exists
 
-    When I drag "[data-cy=\"component-definition-<element>\"]" onto "[data-cy=\"modelizer-model-view-draw-root\"]"
-    Then I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>_\"]" exists
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"] [id^=\"<element>_\"]" appear 1 time on screen
+    When I drag '[data-cy="component-definition-<element>"]' onto '[data-cy="modelizer-model-view-draw-root"]'
+    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' exists
+    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' appear 1 time on screen
 
     Examples:
       | element               |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -7,7 +7,7 @@ Feature: Test modelizer model view: add plugin component
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -18,11 +18,11 @@ Feature: Test modelizer model view: add plugin component
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario Outline: Click on the <element> component should display it on the page
-    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' not exists
+    Then I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>"]' not exists
 
     When I click on '[data-cy="component-definition_<element>"]'
-    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' exists
-    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' appear 1 time on screen
+    Then I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>"]' appear 1 time on screen
 
     Examples:
       | element               |
@@ -45,11 +45,11 @@ Feature: Test modelizer model view: add plugin component
       | aws_key_pair          |
 
   Scenario Outline: Dragging the <element> component should display it on the page
-    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' not exists
+    Then I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>_"]' not exists
 
-    When I drag '[data-cy="component-definition_<element>"]' onto '[data-cy="modelizer-model-view"] [data-cy="draw-root"]'
-    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' exists
-    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' appear 1 time on screen
+    When I drag '[data-cy="component-definition_<element>"]' onto '[data-cy="modelizer-model-view"] [data-cy="draw-container"]'
+    Then I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"] [id^="<element>"]' appear 1 time on screen
 
     Examples:
       | element               |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -4,15 +4,15 @@ Feature: Test modelizer model view: add plugin component
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is 'terrator-plugin'
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -20,7 +20,7 @@ Feature: Test modelizer model view: add plugin component
   Scenario Outline: Click on the <element> component should display it on the page
     Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' not exists
 
-    When I click on '[data-cy="component-definition-<element>"]'
+    When I click on '[data-cy="component-definition_<element>"]'
     Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' exists
     And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' appear 1 time on screen
 
@@ -47,9 +47,9 @@ Feature: Test modelizer model view: add plugin component
   Scenario Outline: Dragging the <element> component should display it on the page
     Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' not exists
 
-    When I drag '[data-cy="component-definition-<element>"]' onto '[data-cy="modelizer-model-view-draw-root"]'
-    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' exists
-    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>_"]' appear 1 time on screen
+    When I drag '[data-cy="component-definition_<element>"]' onto '[data-cy="modelizer-model-view"] [data-cy="draw-root"]'
+    Then I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' exists
+    And  I expect '[data-cy="modelizer-model-view-draw-root"] [id^="<element>"]' appear 1 time on screen
 
     Examples:
       | element               |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -8,8 +8,8 @@ Feature: Test modelizer model view: add plugin component
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/display.component.feature
@@ -7,9 +7,9 @@ Feature: Test modelizer model view: add plugin component
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -7,7 +7,7 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -8,8 +8,8 @@ Feature: Test modelizer model view: plugin initialization
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario Outline: Set text as "<filter>" should display only one element

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -7,19 +7,19 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario Outline: Set text as "<filter>" should display only one element
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"plugin-definitions\"]" appear 1 time on screen
-    And  I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
+    And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on "[data-cy=\"filter-plugin-definitions\"]" text "<filter>"
-    And  I expect "[class*=\"component-definition-card\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"component-definition-<filter>\"]" exists
+    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    And  I expect '[class*="component-definition-card"]' appear 1 time on screen
+    And  I expect '[data-cy="component-definition-<filter>"]' exists
 
     Examples:
       | filter                |
@@ -40,14 +40,14 @@ Feature: Test modelizer model view: plugin initialization
       | aws_key_pair          |
 
   Scenario Outline: Set text as "<filter>" should display only two elements
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"plugin-definitions\"]" appear 1 time on screen
-    And  I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
+    And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on "[data-cy=\"filter-plugin-definitions\"]" text "<filter>"
-    And  I expect "[class*=\"component-definition-card\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"component-definition-<element1>\"]" exists
-    And  I expect "[data-cy=\"component-definition-<element2>\"]" exists
+    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    And  I expect '[class*="component-definition-card"]' appear 2 times on screen
+    And  I expect '[data-cy="component-definition-<element1>"]' exists
+    And  I expect '[data-cy="component-definition-<element2>"]' exists
 
     Examples:
       | filter       | element1              | element2             |
@@ -60,12 +60,12 @@ Feature: Test modelizer model view: plugin initialization
       | route53      | aws_route53_zone      | aws_route53_record   |
 
   Scenario Outline: Set text as "<filter>" should not display any elements.
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"plugin-definitions\"]" appear 1 time on screen
-    And  I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
+    And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on "[data-cy=\"filter-plugin-definitions\"]" text "<filter>"
-    And  I expect "[class*=\"component-definition-card\"]" appear 0 time on screen
+    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    And  I expect '[class*="component-definition-card"]' appear 0 time on screen
     Examples:
       | filter    |
       | bad       |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -7,9 +7,9 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario Outline: Set text as "<filter>" should display only one element

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -13,11 +13,11 @@ Feature: Test modelizer model view: plugin initialization
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario Outline: Set text as "<filter>" should display only one element
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
     And  I expect '[class*="component-definition-card"]' appear 1 time on screen
     And  I expect '[data-cy="component-definition_<filter>"]' exists
 
@@ -40,11 +40,11 @@ Feature: Test modelizer model view: plugin initialization
       | aws_key_pair          |
 
   Scenario Outline: Set text as "<filter>" should display only two elements
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
     And  I expect '[class*="component-definition-card"]' appear 2 times on screen
     And  I expect '[data-cy="component-definition_<element1>"]' exists
     And  I expect '[data-cy="component-definition_<element2>"]' exists
@@ -60,11 +60,11 @@ Feature: Test modelizer model view: plugin initialization
       | route53      | aws_route53_zone      | aws_route53_record   |
 
   Scenario Outline: Set text as "<filter>" should not display any elements.
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
     And  I expect '[class*="component-definition-card"]' appear 0 time on screen
     Examples:
       | filter    |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -19,7 +19,7 @@ Feature: Test modelizer model view: plugin initialization
 
     When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
     And  I expect '[class*="component-definition-card"]' appear 1 time on screen
-    And  I expect '[data-cy="component-definition-<filter>"]' exists
+    And  I expect '[data-cy="component-definition_<filter>"]' exists
 
     Examples:
       | filter                |
@@ -46,8 +46,8 @@ Feature: Test modelizer model view: plugin initialization
 
     When I set on '[data-cy="filter-plugin-definitions"]' text "<filter>"
     And  I expect '[class*="component-definition-card"]' appear 2 times on screen
-    And  I expect '[data-cy="component-definition-<element1>"]' exists
-    And  I expect '[data-cy="component-definition-<element2>"]' exists
+    And  I expect '[data-cy="component-definition_<element1>"]' exists
+    And  I expect '[data-cy="component-definition_<element2>"]' exists
 
     Examples:
       | filter       | element1              | element2             |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/filter.plugin.feature
@@ -4,20 +4,20 @@ Feature: Test modelizer model view: plugin initialization
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-  Scenario Outline: Set text as "<filter>" should display only one element
+  Scenario Outline: Set text as '<filter>'should display only one element
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text '<filter>'
     And  I expect '[class*="component-definition-card"]' appear 1 time on screen
     And  I expect '[data-cy="component-definition_<filter>"]' exists
 
@@ -39,12 +39,12 @@ Feature: Test modelizer model view: plugin initialization
       | aws_db_instance       |
       | aws_key_pair          |
 
-  Scenario Outline: Set text as "<filter>" should display only two elements
+  Scenario Outline: Set text as '<filter>' should display only two elements
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text '<filter>'
     And  I expect '[class*="component-definition-card"]' appear 2 times on screen
     And  I expect '[data-cy="component-definition_<element1>"]' exists
     And  I expect '[data-cy="component-definition_<element2>"]' exists
@@ -59,12 +59,12 @@ Feature: Test modelizer model view: plugin initialization
       | subnet       | aws_subnet            | aws_db_subnet_group  |
       | route53      | aws_route53_zone      | aws_route53_record   |
 
-  Scenario Outline: Set text as "<filter>" should not display any elements.
+  Scenario Outline: Set text as '<filter>' should not display any elements.
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
 
-    When I set on '[data-cy="definitions-filter-input"]' text "<filter>"
+    When I set on '[data-cy="definitions-filter-input"]' text '<filter>'
     And  I expect '[class*="component-definition-card"]' appear 0 time on screen
     Examples:
       | filter    |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -7,7 +7,7 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -13,11 +13,11 @@ Feature: Test modelizer model view: plugin initialization
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Plugin test should appear in component definitions list
-    Then I expect '[data-cy="plugin-definitions-terrator-plugin"]' exists
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
+    Then I expect '[data-cy="component-defnitions-item_terrator-plugin"]' exists
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
 
   Scenario: Should have only one plugin installed with all these definitions
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
     And  I expect '[data-cy="component-definition_<element>"]' exists

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -4,17 +4,17 @@ Feature: Test modelizer model view: plugin initialization
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
   Scenario: Plugin test should appear in component definitions list
     Then I expect '[data-cy="component-defnitions-item_terrator-plugin"]' exists
-    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is 'terrator-plugin'
 
   Scenario: Should have only one plugin installed with all these definitions
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -20,7 +20,7 @@ Feature: Test modelizer model view: plugin initialization
     When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
     Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
     And  I expect '[class*="component-definition-card"]' appear 18 times on screen
-    And  I expect '[data-cy="component-definition-<element>"]' exists
+    And  I expect '[data-cy="component-definition_<element>"]' exists
 
     Examples:
       | element               |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -7,20 +7,20 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Plugin test should appear in component definitions list
-    Then I expect "[data-cy=\"plugin-definitions-terrator-plugin\"]" exists
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"] [data-cy=\"plugin-definitions-title\"]" is "terrator-plugin"
+    Then I expect '[data-cy="plugin-definitions-terrator-plugin"]' exists
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
 
   Scenario: Should have only one plugin installed with all these definitions
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"plugin-definitions\"]" appear 1 time on screen
-    And  I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
-    And  I expect "[data-cy=\"component-definition-<element>\"]" exists
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="plugin-definitions"]' appear 1 time on screen
+    And  I expect '[class*="component-definition-card"]' appear 18 times on screen
+    And  I expect '[data-cy="component-definition-<element>"]' exists
 
     Examples:
       | element               |

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -7,9 +7,9 @@ Feature: Test modelizer model view: plugin initialization
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Plugin test should appear in component definitions list

--- a/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
+++ b/cypress/e2e/ModelizerPage/ModelView/plugin/init.plugin.feature
@@ -8,8 +8,8 @@ Feature: Test modelizer model view: plugin initialization
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
   Scenario: Plugin test should appear in component definitions list

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -11,10 +11,10 @@ Feature: Test switch model to text view: add component/link
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
 
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario: Plugin test installed in component definitions list (Model view) should create project configuration file (Text view)
@@ -39,7 +39,7 @@ Feature: Test switch model to text view: add component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     And  I wait 1 second
     And  I click on '[data-cy="component-definition-aws"]'
     Then I expect '[id^="aws"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -7,7 +7,7 @@ Feature: Test switch model to text view: add component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -8,8 +8,8 @@ Feature: Test switch model to text view: add component/link
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -18,8 +18,8 @@ Feature: Test switch model to text view: add component/link
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario: Plugin test installed in component definitions list (Model view) should create project configuration file (Text view)
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' not exists
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -27,16 +27,16 @@ Feature: Test switch model to text view: add component/link
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
   Scenario: Add a component (Model view) should create project configuration file (Text view)
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' not exists
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
     When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
@@ -44,8 +44,8 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[data-cy="component-definition-aws"]'
     Then I expect '[id^="aws"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -55,8 +55,8 @@ Feature: Test switch model to text view: add component/link
 
   Scenario: Update plugin file content with a new object (Text view) should display the corresponding plugin component (Model view)
     When I click on '[data-cy="component-definition-aws"]'
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -68,8 +68,8 @@ Feature: Test switch model to text view: add component/link
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "module \"server\" {}"
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect '[id^="server"]' exists
     But  I expect '[id^="aws"]' not exists
@@ -84,8 +84,8 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[id^="aws_internet_gateway"]'
     Then I expect '[class="link"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
@@ -101,8 +101,8 @@ Feature: Test switch model to text view: add component/link
     And  I wait 1 second
     And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
@@ -116,8 +116,8 @@ Feature: Test switch model to text view: add component/link
 
     When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" { gateway_id = [\"aws_internet_gateway_1"] } resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
     And  I wait 2 seconds
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I wait 1 second
     And  I expect '[id^="aws_subnet"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -21,8 +21,8 @@ Feature: Test switch model to text view: add component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' not exists
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
@@ -30,8 +30,8 @@ Feature: Test switch model to text view: add component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' not exists
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
@@ -41,30 +41,30 @@ Feature: Test switch model to text view: add component/link
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-aws"]'
+    And  I click on '[data-cy="component-definition_aws"]'
     Then I expect '[id^="aws"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "leto-modelizer.config.json"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
 
   Scenario: Update plugin file content with a new object (Text view) should display the corresponding plugin component (Model view)
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "module \"server\" {}"
@@ -75,9 +75,9 @@ Feature: Test switch model to text view: add component/link
     But  I expect '[id^="aws"]' not exists
 
   Scenario: Link two components (Model view) should update plugin file content with new attributes properties (Text view)
-    When I click on '[data-cy="component-definition-aws_subnet"]'
+    When I click on '[data-cy="component-definition_aws_subnet"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
+    And  I click on '[data-cy="component-definition_aws_internet_gateway"]'
     And  I wait 1 second
     And  I click on '[id^="aws_subnet"]'
     And  I click on '[id="create-link"]'
@@ -91,15 +91,15 @@ Feature: Test switch model to text view: add component/link
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
   Scenario: Add link attributes inside plugin file content (Text view) should display link between two components (Model view)
-    When I click on '[data-cy="component-definition-aws_subnet"]'
+    When I click on '[data-cy="component-definition_aws_subnet"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
+    And  I click on '[data-cy="component-definition_aws_internet_gateway"]'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
@@ -108,7 +108,7 @@ Feature: Test switch model to text view: add component/link
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -4,39 +4,39 @@ Feature: Test switch model to text view: add component/link
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is 'terrator-plugin'
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario: Plugin test installed in component definitions list (Model view) should create project configuration file (Text view)
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' not exists
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
-    And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
+    And  I expect active file content to contain '{.*"terrator-plugin":.*{}}'
 
   Scenario: Add a component (Model view) should create project configuration file (Text view)
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' not exists
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
-    And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
+    And  I expect active file content to contain '{.*"terrator-plugin":.*{}}'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
@@ -45,31 +45,31 @@ Feature: Test switch model to text view: add component/link
     Then I expect '[id^="aws"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "leto-modelizer.config.json"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "provider.*\"aws\".*{}"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'leto-modelizer.config.json'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'provider.*"aws".*{}'
 
   Scenario: Update plugin file content with a new object (Text view) should display the corresponding plugin component (Model view)
     When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
 
-    When I set active file content to "module \"server\" {}"
+    When I set active file content to 'module "server" {}'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="server"]' exists
     But  I expect '[id^="aws"]' not exists
@@ -85,16 +85,16 @@ Feature: Test switch model to text view: add component/link
     Then I expect '[class="link"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
-    And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
+    And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 
   Scenario: Add link attributes inside plugin file content (Text view) should display link between two components (Model view)
     When I click on '[data-cy="component-definition_aws_subnet"]'
@@ -102,22 +102,22 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[data-cy="component-definition_aws_internet_gateway"]'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
-    And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
-    But  I expect active file content to not contain "gateway_id.*=.*\[\"aws_internet_gateway_1\"\]"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{}'
+    And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
+    But  I expect active file content to not contain 'gateway_id.*=.*\["aws_internet_gateway_1"\]'
 
-    When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" { gateway_id = [\"aws_internet_gateway_1"] } resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
+    When I set active file content to 'resource "aws_subnet" "aws_subnet_1" { gateway_id = \["aws_internet_gateway_1"\] } resource "aws_internet_gateway" "aws_internet_gateway_1" {}'
     And  I wait 2 seconds
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I wait 1 second
     And  I expect '[id^="aws_subnet"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -7,119 +7,119 @@ Feature: Test switch model to text view: add component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"] [data-cy=\"plugin-definitions-title\"]" is "terrator-plugin"
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
 
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   Scenario: Plugin test installed in component definitions list (Model view) should create project configuration file (Text view)
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" not exists
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
   Scenario: Add a component (Model view) should create project configuration file (Text view)
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" not exists
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
     And  I expect active file content to contain "{.*\"terrator-plugin\":.*{}}"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-aws\"]"
-    Then I expect "[id^=\"aws\"]" exists
+    And  I click on '[data-cy="component-definition-aws"]'
+    Then I expect '[id^="aws"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "leto-modelizer.config.json"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
 
   Scenario: Update plugin file content with a new object (Text view) should display the corresponding plugin component (Model view)
-    When I click on "[data-cy=\"component-definition-aws\"]"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="component-definition-aws"]'
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "module \"server\" {}"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And  I expect "[id^=\"server\"]" exists
-    But  I expect "[id^=\"aws\"]" not exists
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[id^="server"]' exists
+    But  I expect '[id^="aws"]' not exists
 
   Scenario: Link two components (Model view) should update plugin file content with new attributes properties (Text view)
-    When I click on "[data-cy=\"component-definition-aws_subnet\"]"
+    When I click on '[data-cy="component-definition-aws_subnet"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-aws_internet_gateway\"]"
+    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
     And  I wait 1 second
-    And  I click on "[id^=\"aws_subnet\"]"
-    And  I click on "[id=\"create-link\"]"
-    And  I click on "[id^=\"aws_internet_gateway\"]"
-    Then I expect "[class=\"link\"]" exists
+    And  I click on '[id^="aws_subnet"]'
+    And  I click on '[id="create-link"]'
+    And  I click on '[id^="aws_internet_gateway"]'
+    Then I expect '[class="link"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
   Scenario: Add link attributes inside plugin file content (Text view) should display link between two components (Model view)
-    When I click on "[data-cy=\"component-definition-aws_subnet\"]"
+    When I click on '[data-cy="component-definition-aws_subnet"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-aws_internet_gateway\"]"
+    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
     But  I expect active file content to not contain "gateway_id.*=.*\[\"aws_internet_gateway_1\"\]"
 
-    When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" { gateway_id = [\"aws_internet_gateway_1\"] } resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
+    When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" { gateway_id = [\"aws_internet_gateway_1"] } resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
     And  I wait 2 seconds
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I wait 1 second
-    And  I expect "[id^=\"aws_subnet\"]" exists
-    And  I expect "[id^=\"aws_internet_gateway\"]" exists
-    And  I expect "[class=\"link\"]" exists
+    And  I expect '[id^="aws_subnet"]' exists
+    And  I expect '[id^="aws_internet_gateway"]' exists
+    And  I expect '[class="link"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -37,7 +37,7 @@ Feature: Test switch model to text view: add component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     And  I wait 1 second
@@ -70,7 +70,7 @@ Feature: Test switch model to text view: add component/link
     When I set active file content to "module \"server\" {}"
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="server"]' exists
     But  I expect '[id^="aws"]' not exists
 
@@ -118,7 +118,7 @@ Feature: Test switch model to text view: add component/link
     And  I wait 2 seconds
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I wait 1 second
     And  I expect '[id^="aws_subnet"]' exists
     And  I expect '[id^="aws_internet_gateway"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -7,9 +7,9 @@ Feature: Test switch model to text view: add component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -20,13 +20,13 @@ Feature: Test switch model to text view: delete component/link
   @skip
     # TODO: Remove @skip tag when https://github.com/ditrit/leto-modelizer/issues/128 is done
   Scenario: Delete a component (Model view) should remove plugin file (Text view)
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     Then I expect '[id^="aws"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
 
@@ -41,25 +41,25 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    But  I expect '[data-cy="file-label-new_file.tf"]' not exists
+    But  I expect '[data-cy="file_new_file.tf"]' not exists
 
   Scenario: Delete one of two components (Model view) should remove corresponding object inside plugin file content (Text view)
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-server"]'
+    And  I click on '[data-cy="component-definition_server"]'
     Then I expect '[id^="aws"]' exists
     And  I expect '[id^="server"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
     And  I expect active file content to contain "provider.*\"server\".*{}"
@@ -83,17 +83,17 @@ Feature: Test switch model to text view: delete component/link
 
   Scenario: Remove object inside plugin file content (Text view) should remove related component (Model view)
     #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - new_file.tf)
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "[]"
@@ -103,19 +103,19 @@ Feature: Test switch model to text view: delete component/link
     But  I expect '[id^="aws"]' not exists
 
   Scenario: Remove one of the two objects inside plugin file content (Text view) should only display the remaining component
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-server"]'
+    And  I click on '[data-cy="component-definition_server"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "provider \"aws\" {}"
@@ -126,21 +126,21 @@ Feature: Test switch model to text view: delete component/link
     But  I expect '[id^="server"]' not exists
 
   Scenario: Delete plugin file (Text view) should remove related component (Model view)
-    When I click on '[data-cy="component-definition-aws"]'
+    When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-new_file.tf"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-new_file.tf"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_new_file.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_new_file.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -149,7 +149,7 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
+    And  I expect '[data-cy="file_new_file.tf"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
@@ -157,9 +157,9 @@ Feature: Test switch model to text view: delete component/link
     And  I expect '[id^="aws"]' not exists
 
   Scenario: Delete a link between two components (Model view) should remove corresponding attribute in object inside plugin file content (Text view)
-    When I click on '[data-cy="component-definition-aws_subnet"]'
+    When I click on '[data-cy="component-definition_aws_subnet"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
+    And  I click on '[data-cy="component-definition_aws_internet_gateway"]'
     And  I wait 1 second
     And  I click on '[id^="aws_subnet"]'
     And  I click on '[id="create-link"]'
@@ -169,13 +169,13 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
@@ -198,9 +198,9 @@ Feature: Test switch model to text view: delete component/link
     But  I expect active file content to not contain "gateway_id.*=.*\[\"aws_internet_gateway_1\"\]"
 
   Scenario: Remove link attribute inside plugin file content (Text view) should remove the link between the two components (Model view)
-    When I click on '[data-cy="component-definition-aws_subnet"]'
+    When I click on '[data-cy="component-definition_aws_subnet"]'
     And  I wait 1 second
-    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
+    And  I click on '[data-cy="component-definition_aws_internet_gateway"]'
     And  I wait 1 second
     And  I click on '[id^="aws_subnet"]'
     And  I click on '[id="create-link"]'
@@ -210,13 +210,13 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -7,9 +7,9 @@ Feature: Test switch model to text view: delete component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -7,7 +7,7 @@ Feature: Test switch model to text view: delete component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -143,7 +143,7 @@ Feature: Test switch model to text view: delete component/link
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-new_file.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -8,8 +8,8 @@ Feature: Test switch model to text view: delete component/link
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
     And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
@@ -146,7 +146,7 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-new_file.tf"]' not exists

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -7,224 +7,224 @@ Feature: Test switch model to text view: delete component/link
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"plugin-definitions-terrator-plugin\"] [data-cy=\"plugin-definitions-title\"]" is "terrator-plugin"
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
 
-    When I click on "[data-cy=\"plugin-definitions-terrator-plugin\"]"
-    Then I expect "[class*=\"component-definition-card\"]" appear 18 times on screen
+    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   @skip
     # TODO: Remove @skip tag when https://github.com/ditrit/leto-modelizer/issues/128 is done
   Scenario: Delete a component (Model view) should remove plugin file (Text view)
-    When I click on "[data-cy=\"component-definition-aws\"]"
-    Then I expect "[id^=\"aws\"]" exists
+    When I click on '[data-cy="component-definition-aws"]'
+    Then I expect '[id^="aws"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
-    When I click on "[id^=\"aws\"]"
-    And  I click on "[id=\"remove-component\"]"
-    Then I expect "[id^=\"aws\"]" not exists
+    When I click on '[id^="aws"]'
+    And  I click on '[id="remove-component"]'
+    Then I expect '[id^="aws"]' not exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    But  I expect "[data-cy=\"file-label-new_file.tf\"]" not exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    But  I expect '[data-cy="file-label-new_file.tf"]' not exists
 
   Scenario: Delete one of two components (Model view) should remove corresponding object inside plugin file content (Text view)
-    When I click on "[data-cy=\"component-definition-aws\"]"
+    When I click on '[data-cy="component-definition-aws"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-server\"]"
-    Then I expect "[id^=\"aws\"]" exists
-    And  I expect "[id^=\"server\"]" exists
+    And  I click on '[data-cy="component-definition-server"]'
+    Then I expect '[id^="aws"]' exists
+    And  I expect '[id^="server"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
     And  I expect active file content to contain "provider.*\"server\".*{}"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
     When I wait 1 second
-    And  I click on "[id^=\"aws\"]"
-    And  I click on "[id=\"remove-component\"]"
+    And  I click on '[id^="aws"]'
+    And  I click on '[id="remove-component"]'
     And  I wait 1 second
-    Then I expect "[id^=\"server\"]" exists
-    And  I expect "[id^=\"aws\"]" not exists
+    Then I expect '[id^="server"]' exists
+    And  I expect '[id^="aws"]' not exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect active file content to contain "provider.*\"server\".*{}"
     But  I expect active file content to not contain "provider.*\"aws\".*{}"
 
   Scenario: Remove object inside plugin file content (Text view) should remove related component (Model view)
     #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - new_file.tf)
-    When I click on "[data-cy=\"component-definition-aws\"]"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="component-definition-aws"]'
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "[]"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    But  I expect "[id^=\"aws\"]" not exists
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    But  I expect '[id^="aws"]' not exists
 
   Scenario: Remove one of the two objects inside plugin file content (Text view) should only display the remaining component
-    When I click on "[data-cy=\"component-definition-aws\"]"
+    When I click on '[data-cy="component-definition-aws"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-server\"]"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    And  I click on '[data-cy="component-definition-server"]'
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "provider \"aws\" {}"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And  I expect "[id^=\"aws\"]" exists
-    But  I expect "[id^=\"server\"]" not exists
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[id^="aws"]' exists
+    But  I expect '[id^="server"]' not exists
 
   Scenario: Delete plugin file (Text view) should remove related component (Model view)
-    When I click on "[data-cy=\"component-definition-aws\"]"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="component-definition-aws"]'
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-new_file.tf\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-new_file.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-new_file.tf"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" not exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-label-new_file.tf"]' not exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And  I expect "[id^=\"aws\"]" not exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[id^="aws"]' not exists
 
   Scenario: Delete a link between two components (Model view) should remove corresponding attribute in object inside plugin file content (Text view)
-    When I click on "[data-cy=\"component-definition-aws_subnet\"]"
+    When I click on '[data-cy="component-definition-aws_subnet"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-aws_internet_gateway\"]"
+    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
     And  I wait 1 second
-    And  I click on "[id^=\"aws_subnet\"]"
-    And  I click on "[id=\"create-link\"]"
-    And  I click on "[id^=\"aws_internet_gateway\"]"
-    Then I expect "[class=\"link\"]" exists
+    And  I click on '[id^="aws_subnet"]'
+    And  I click on '[id="create-link"]'
+    And  I click on '[id^="aws_internet_gateway"]'
+    Then I expect '[class="link"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And  I expect "[class=\"link\"]" appear 1 time on screen
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[class="link"]' appear 1 time on screen
 
     #  NOTE: must force click because the following two elements are covered by an overflowing svg element
-    When I force click on "[class=\"link\"]"
-    And  I force click on "[id=\"remove-link\"]"
-    Then I expect "[class=\"link\"]" not exists
+    When I force click on '[class="link"]'
+    And  I force click on '[id="remove-link"]'
+    Then I expect '[class="link"]' not exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
     But  I expect active file content to not contain "gateway_id.*=.*\[\"aws_internet_gateway_1\"\]"
 
   Scenario: Remove link attribute inside plugin file content (Text view) should remove the link between the two components (Model view)
-    When I click on "[data-cy=\"component-definition-aws_subnet\"]"
+    When I click on '[data-cy="component-definition-aws_subnet"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"component-definition-aws_internet_gateway\"]"
+    And  I click on '[data-cy="component-definition-aws_internet_gateway"]'
     And  I wait 1 second
-    And  I click on "[id^=\"aws_subnet\"]"
-    And  I click on "[id=\"create-link\"]"
-    And  I click on "[id^=\"aws_internet_gateway\"]"
-    Then I expect "[class=\"link\"]" exists
+    And  I click on '[id^="aws_subnet"]'
+    And  I click on '[id="create-link"]'
+    And  I click on '[id^="aws_internet_gateway"]'
+    Then I expect '[class="link"]' exists
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-label-new_file.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-leto-modelizer.config.json\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "new_file.tf"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "leto-modelizer.config.json"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
 
     When I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-new_file.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "new_file.tf"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-new_file.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
     When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" {} resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
-    And  I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And  I expect "[class=\"link\"]" not exists
-    And  I expect "[id^=\"aws_subnet\"]" exists
-    And  I expect "[id^=\"aws_internet_gateway\"]" exists
+    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[class="link"]' not exists
+    And  I expect '[id^="aws_subnet"]' exists
+    And  I expect '[id^="aws_internet_gateway"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -11,10 +11,10 @@ Feature: Test switch model to text view: delete component/link
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="plugin-definitions-terrator-plugin"] [data-cy="plugin-definitions-title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
 
-    When I click on '[data-cy="plugin-definitions-terrator-plugin"]'
+    When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
 
   @skip

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -23,23 +23,23 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="component-definition-aws"]'
     Then I expect '[id^="aws"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
     And  I expect active file content to contain "provider.*\"aws\".*{}"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
     When I click on '[id^="aws"]'
     And  I click on '[id="remove-component"]'
     Then I expect '[id^="aws"]' not exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     But  I expect '[data-cy="file-label-new_file.tf"]' not exists
 
@@ -50,8 +50,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[id^="aws"]' exists
     And  I expect '[id^="server"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -64,8 +64,8 @@ Feature: Test switch model to text view: delete component/link
     And  I expect active file content to contain "provider.*\"aws\".*{}"
     And  I expect active file content to contain "provider.*\"server\".*{}"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
 
     When I wait 1 second
@@ -75,8 +75,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[id^="server"]' exists
     And  I expect '[id^="aws"]' not exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect active file content to contain "provider.*\"server\".*{}"
     But  I expect active file content to not contain "provider.*\"aws\".*{}"
@@ -84,8 +84,8 @@ Feature: Test switch model to text view: delete component/link
   Scenario: Remove object inside plugin file content (Text view) should remove related component (Model view)
     #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - new_file.tf)
     When I click on '[data-cy="component-definition-aws"]'
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -97,8 +97,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "[]"
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     But  I expect '[id^="aws"]' not exists
 
@@ -106,8 +106,8 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="component-definition-aws"]'
     And  I wait 1 second
     And  I click on '[data-cy="component-definition-server"]'
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -119,16 +119,16 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
 
     When I set active file content to "provider \"aws\" {}"
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect '[id^="aws"]' exists
     But  I expect '[id^="server"]' not exists
 
   Scenario: Delete plugin file (Text view) should remove related component (Model view)
     When I click on '[data-cy="component-definition-aws"]'
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -151,8 +151,8 @@ Feature: Test switch model to text view: delete component/link
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-new_file.tf"]' not exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect '[id^="aws"]' not exists
 
@@ -166,8 +166,8 @@ Feature: Test switch model to text view: delete component/link
     And  I click on '[id^="aws_internet_gateway"]'
     Then I expect '[class="link"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -180,8 +180,8 @@ Feature: Test switch model to text view: delete component/link
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect '[class="link"]' appear 1 time on screen
 
@@ -190,8 +190,8 @@ Feature: Test switch model to text view: delete component/link
     And  I force click on '[id="remove-link"]'
     Then I expect '[class="link"]' not exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
@@ -207,8 +207,8 @@ Feature: Test switch model to text view: delete component/link
     And  I click on '[id^="aws_internet_gateway"]'
     Then I expect '[class="link"]' exists
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-label-new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-label-leto-modelizer.config.json"]' appear 2 times on screen
@@ -222,8 +222,8 @@ Feature: Test switch model to text view: delete component/link
     And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
 
     When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" {} resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
-    And  I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect '[class="link"]' not exists
     And  I expect '[id^="aws_subnet"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -32,7 +32,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I click on '[id^="aws"]'
     And  I click on '[id="remove-component"]'
@@ -66,7 +66,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I wait 1 second
     And  I click on '[id^="aws"]'
@@ -99,7 +99,7 @@ Feature: Test switch model to text view: delete component/link
     When I set active file content to "[]"
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     But  I expect '[id^="aws"]' not exists
 
   Scenario: Remove one of the two objects inside plugin file content (Text view) should only display the remaining component
@@ -121,7 +121,7 @@ Feature: Test switch model to text view: delete component/link
     When I set active file content to "provider \"aws\" {}"
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="aws"]' exists
     But  I expect '[id^="server"]' not exists
 
@@ -153,7 +153,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="aws"]' not exists
 
   Scenario: Delete a link between two components (Model view) should remove corresponding attribute in object inside plugin file content (Text view)
@@ -182,7 +182,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[class="link"]' appear 1 time on screen
 
     #  NOTE: must force click because the following two elements are covered by an overflowing svg element
@@ -224,7 +224,7 @@ Feature: Test switch model to text view: delete component/link
     When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" {} resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[class="link"]' not exists
     And  I expect '[id^="aws_subnet"]' exists
     And  I expect '[id^="aws_internet_gateway"]' exists

--- a/cypress/e2e/ModelizerPage/SwitchView/delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/delete.feature
@@ -4,15 +4,15 @@ Feature: Test switch model to text view: delete component/link
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
     And  I expect '[data-cy="component-defnitions-item_terrator-plugin"]' appear 1 time on screen
-    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is "terrator-plugin"
+    And  I expect '[data-cy="component-defnitions-item_terrator-plugin"] [data-cy="title"]' is 'terrator-plugin'
 
     When I click on '[data-cy="component-defnitions-item_terrator-plugin"]'
     Then I expect '[class*="component-definition-card"]' appear 18 times on screen
@@ -24,14 +24,14 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[id^="aws"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "provider.*\"aws\".*{}"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'provider.*"aws".*{}'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I click on '[id^="aws"]'
@@ -39,7 +39,7 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[id^="aws"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     But  I expect '[data-cy="file_new_file.tf"]' not exists
 
@@ -51,21 +51,21 @@ Feature: Test switch model to text view: delete component/link
     And  I expect '[id^="server"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "provider.*\"aws\".*{}"
-    And  I expect active file content to contain "provider.*\"server\".*{}"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'provider.*"aws".*{}'
+    And  I expect active file content to contain 'provider.*"server".*{}'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
 
     When I wait 1 second
@@ -76,29 +76,29 @@ Feature: Test switch model to text view: delete component/link
     And  I expect '[id^="aws"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect active file content to contain "provider.*\"server\".*{}"
-    But  I expect active file content to not contain "provider.*\"aws\".*{}"
+    And  I expect active file content to contain 'provider.*"server".*{}'
+    But  I expect active file content to not contain 'provider.*"aws".*{}'
 
   Scenario: Remove object inside plugin file content (Text view) should remove related component (Model view)
     #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - new_file.tf)
     When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
 
-    When I set active file content to "[]"
+    When I set active file content to '[]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     But  I expect '[id^="aws"]' not exists
 
@@ -107,20 +107,20 @@ Feature: Test switch model to text view: delete component/link
     And  I wait 1 second
     And  I click on '[data-cy="component-definition_server"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
 
-    When I set active file content to "provider \"aws\" {}"
+    When I set active file content to 'provider "aws" {}'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="aws"]' exists
     But  I expect '[id^="server"]' not exists
@@ -128,16 +128,16 @@ Feature: Test switch model to text view: delete component/link
   Scenario: Delete plugin file (Text view) should remove related component (Model view)
     When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
 
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_new_file.tf"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_new_file.tf"]'
@@ -147,12 +147,12 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file_new_file.tf"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[id^="aws"]' not exists
 
@@ -167,21 +167,21 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[class="link"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
-    And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
+    And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[class="link"]' appear 1 time on screen
 
@@ -191,11 +191,11 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[class="link"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
-    And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{}"
-    And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
-    But  I expect active file content to not contain "gateway_id.*=.*\[\"aws_internet_gateway_1\"\]"
+    And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{}'
+    And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
+    But  I expect active file content to not contain 'gateway_id.*=.*\["aws_internet_gateway_1"\]'
 
   Scenario: Remove link attribute inside plugin file content (Text view) should remove the link between the two components (Model view)
     When I click on '[data-cy="component-definition_aws_subnet"]'
@@ -208,22 +208,22 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[class="link"]' exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file_new_file.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "new_file.tf"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "leto-modelizer.config.json"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
     When I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "new_file.tf"
-    And  I expect active file content to contain "resource.*\"aws_subnet\".*\"aws_subnet_1\".*{.*gateway_id.*=.*\[\"aws_internet_gateway_1\"\]}"
-    And  I expect active file content to contain "resource.*\"aws_internet_gateway\".*\"aws_internet_gateway_1\".*{}"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
+    And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 
-    When I set active file content to "resource \"aws_subnet\" \"aws_subnet_1\" {} resource \"aws_internet_gateway\" \"aws_internet_gateway_1\" {}"
+    When I set active file content to 'resource "aws_subnet" "aws_subnet_1" {} resource "aws_internet_gateway" "aws_internet_gateway_1" {}'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect '[class="link"]' not exists
     And  I expect '[id^="aws_subnet"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -17,20 +17,20 @@ Feature: Test modelizer text view: add file
     And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: An unmodified file should not have the "add" action inside file explorer menu
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-README.md"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-README.md"]'
-    Then I expect '[data-cy="file-label-README.md"].file-status-unmodified' exists
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-button_README.md"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_README.md"]'
+    Then I expect '[data-cy="file_README.md"].file-status-unmodified' exists
     And  I expect '[data-cy="file-explorer-action-menu"]' exists
     But  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' not exists
 
   Scenario: Create a file inside the root folder and add it on git should change the file's status
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -41,20 +41,20 @@ Feature: Test modelizer text view: add file
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
+    And  I expect '[data-cy="file_newFile.js"].file-status-untracked' exists
  
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
+    And  I expect '[data-cy="file_newFile.js"].file-status-staged' exists
 
   Scenario: Create a file inside sub-folder and add it on git should change the file's status
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -65,13 +65,13 @@ Feature: Test modelizer text view: add file
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
+    And  I expect '[data-cy="file_terraform/newFile.js"].file-status-untracked' exists
  
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_terraform/newFile.js"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
+    And  I expect '[data-cy="file_terraform/newFile.js"].file-status-staged' exists
     

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: add file
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
@@ -36,8 +36,8 @@ Feature: Test modelizer text view: add file
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen
@@ -60,8 +60,8 @@ Feature: Test modelizer text view: add file
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: add file
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -2,25 +2,25 @@ Feature: Test modelizer text view: add file
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
-  Scenario: An unmodified file should not have the "add" action inside file explorer menu
+  Scenario: An unmodified file should not have the 'add' action inside file explorer menu
     When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
     And  I hover '[data-cy="file-explorer"] [data-cy="file-button_README.md"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_README.md"]'
@@ -36,11 +36,11 @@ Feature: Test modelizer text view: add file
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect ".file-status-untracked" appear 2 times on screen
+    And  I expect '.file-status-untracked' appear 2 times on screen
     And  I expect '[data-cy="file_newFile.js"].file-status-untracked' exists
  
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]' to make it visible
@@ -48,7 +48,7 @@ Feature: Test modelizer text view: add file
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
-    Then I expect "positive" toast to appear with text "File is added &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is added &#129395;!'
     And  I expect '[data-cy="file_newFile.js"].file-status-staged' exists
 
   Scenario: Create a file inside sub-folder and add it on git should change the file's status
@@ -60,11 +60,11 @@ Feature: Test modelizer text view: add file
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect ".file-status-untracked" appear 2 times on screen
+    And  I expect '.file-status-untracked' appear 2 times on screen
     And  I expect '[data-cy="file_terraform/newFile.js"].file-status-untracked' exists
  
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/newFile.js"]' to make it visible
@@ -72,6 +72,6 @@ Feature: Test modelizer text view: add file
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
-    Then I expect "positive" toast to appear with text "File is added &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is added &#129395;!'
     And  I expect '[data-cy="file_terraform/newFile.js"].file-status-staged' exists
     

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -6,72 +6,72 @@ Feature: Test modelizer text view: add file
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: An unmodified file should not have the "add" action inside file explorer menu
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-README.md\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-README.md\"]"
-    Then I expect "[data-cy=\"file-label-README.md\"].file-status-unmodified" exists
-    And  I expect "[data-cy=\"file-explorer-action-menu\"]" exists
-    But  I expect "[data-cy=\"file-explorer-menu-add-file\"]" not exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-README.md"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-README.md"]'
+    Then I expect '[data-cy="file-label-README.md"].file-status-unmodified' exists
+    And  I expect '[data-cy="file-explorer-action-menu"]' exists
+    But  I expect '[data-cy="file-explorer-menu-add-file"]' not exists
 
   Scenario: Create a file inside the root folder and add it on git should change the file's status
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-untracked" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
  
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-add-file\"]"
+    When I click on '[data-cy="file-explorer-menu-add-file"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-staged" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
 
   Scenario: Create a file inside sub-folder and add it on git should change the file's status
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-untracked" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
  
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-add-file\"]"
+    When I click on '[data-cy="file-explorer-menu-add-file"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-staged" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
     

--- a/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/add.file.feature
@@ -26,14 +26,14 @@ Feature: Test modelizer text view: add file
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-README.md"]'
     Then I expect '[data-cy="file-label-README.md"].file-status-unmodified' exists
     And  I expect '[data-cy="file-explorer-action-menu"]' exists
-    But  I expect '[data-cy="file-explorer-menu-add-file"]' not exists
+    But  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' not exists
 
   Scenario: Create a file inside the root folder and add it on git should change the file's status
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -47,7 +47,7 @@ Feature: Test modelizer text view: add file
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-add-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
     And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
 
@@ -57,7 +57,7 @@ Feature: Test modelizer text view: add file
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -71,7 +71,7 @@ Feature: Test modelizer text view: add file
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-add-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
     Then I expect "positive" toast to appear with text "File is added &#129395;!"
     And  I expect '[data-cy="file-label-newFile.js"].file-status-staged' exists
     

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -25,7 +25,7 @@ Feature: Test modelizer text view: create file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -49,7 +49,7 @@ Feature: Test modelizer text view: create file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -72,7 +72,7 @@ Feature: Test modelizer text view: create file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"
@@ -93,7 +93,7 @@ Feature: Test modelizer text view: create file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -6,105 +6,105 @@ Feature: Test modelizer text view: create file and folder
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: Create a file inside the root folder should expand the root folder and open corresponding active tab
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     #  New active tab is open with created file's label
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "newFile.js"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
     #  Created file is added inside file explorer and file tabs
-    And  I expect "[data-cy=\"file-label-newFile.js\"]" appear 2 times on screen
+    And  I expect '[data-cy="file-label-newFile.js"]' appear 2 times on screen
     #  Created file's label is red
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-untracked" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
     #  Root folder is expanded
-    And  I expect "[data-cy=\"file-explorer-icon-{{ projectName }}\"].fa-folder-open" exists
+    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
 
   Scenario: Create a file inside sub-folder should open corresponding active tab and expand the parent folder
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     #  New tab is open with created file's label
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "newFile.js"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
     #  Created file is added inside file explorer and file tabs
-    And  I expect "[data-cy=\"file-label-newFile.js\"]" appear 2 times on screen
+    And  I expect '[data-cy="file-label-newFile.js"]' appear 2 times on screen
     #  Created file's label is red
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-newFile.js\"].file-status-untracked" exists
+    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
     #  Parent folder is expanded
-    And  I expect "[data-cy=\"file-explorer-icon-terraform\"].fa-folder-open" exists
+    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder-open' exists
   
   Scenario: Create a folder inside the root folder should expand root folder
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-folder\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFolder"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFolder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 0 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     #  Created folder is added inside file explorer
-    And  I expect "[data-cy=\"file-label-newFolder\"]" appear 1 time on screen
+    And  I expect '[data-cy="file-label-newFolder"]' appear 1 time on screen
     #  Root folder is expanded, created folder is not expanded
-    And  I expect "[data-cy=\"file-explorer-icon-{{ projectName }}\"].fa-folder-open" exists
-    And  I expect "[data-cy=\"file-explorer-icon-newFolder\"].fa-folder" exists
+    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="file-explorer-icon-newFolder"].fa-folder' exists
 
   Scenario: Create a folder inside folder should expand parent folder
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-folder\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "newFolder"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFolder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
+    And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 0 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     #  Created folder is added inside file explorer
-    And  I expect "[data-cy=\"file-label-newFolder\"]" appear 1 time on screen
+    And  I expect '[data-cy="file-label-newFolder"]' appear 1 time on screen
     #  Root and parent folder are expanded, created folder is not expanded
-    And  I expect "[data-cy=\"file-explorer-icon-{{ projectName }}\"].fa-folder-open" exists
-    And  I expect "[data-cy=\"file-explorer-icon-terraform\"].fa-folder-open" exists
-    And  I expect "[data-cy=\"file-explorer-icon-newFolder\"].fa-folder" exists
+    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder-open' exists
+    And  I expect '[data-cy="file-explorer-icon-newFolder"].fa-folder' exists

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: create file and folder
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -17,12 +17,12 @@ Feature: Test modelizer text view: create file and folder
     And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: Create a file inside the root folder should expand the root folder and open corresponding active tab
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -36,17 +36,17 @@ Feature: Test modelizer text view: create file and folder
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
     #  Created file is added inside file explorer and file tabs
-    And  I expect '[data-cy="file-label-newFile.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file_newFile.js"]' appear 2 times on screen
     #  Created file's label is red
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
+    And  I expect '[data-cy="file_newFile.js"].file-status-untracked' exists
     #  Root folder is expanded
-    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
 
   Scenario: Create a file inside sub-folder should open corresponding active tab and expand the parent folder
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -60,16 +60,16 @@ Feature: Test modelizer text view: create file and folder
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
     #  Created file is added inside file explorer and file tabs
-    And  I expect '[data-cy="file-label-newFile.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file_terraform/newFile.js"]' appear 2 times on screen
     #  Created file's label is red
     And  I expect ".file-status-untracked" appear 2 times on screen
-    And  I expect '[data-cy="file-label-newFile.js"].file-status-untracked' exists
+    And  I expect '[data-cy="file_terraform/newFile.js"].file-status-untracked' exists
     #  Parent folder is expanded
-    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder-open' exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder-icon_terraform"].fa-folder-open' exists
   
   Scenario: Create a folder inside the root folder should expand root folder
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
@@ -82,15 +82,15 @@ Feature: Test modelizer text view: create file and folder
     #  No tab open
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     #  Created folder is added inside file explorer
-    And  I expect '[data-cy="file-label-newFolder"]' appear 1 time on screen
+    And  I expect '[data-cy="folder_newFolder"]' appear 1 time on screen
     #  Root folder is expanded, created folder is not expanded
-    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
-    And  I expect '[data-cy="file-explorer-icon-newFolder"].fa-folder' exists
+    And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_newFolder"].fa-folder' exists
 
   Scenario: Create a folder inside folder should expand parent folder
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
@@ -103,8 +103,8 @@ Feature: Test modelizer text view: create file and folder
     #  No tab open
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     #  Created folder is added inside file explorer
-    And  I expect '[data-cy="file-label-newFolder"]' appear 1 time on screen
+    And  I expect '[data-cy="folder_terraform/newFolder"]' appear 1 time on screen
     #  Root and parent folder are expanded, created folder is not expanded
-    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
-    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder-open' exists
-    And  I expect '[data-cy="file-explorer-icon-newFolder"].fa-folder' exists
+    And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_terraform"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_terraform/newFolder"].fa-folder' exists

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -2,21 +2,21 @@ Feature: Test modelizer text view: create file and folder
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
@@ -28,17 +28,17 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     #  New active tab is open with created file's label
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'newFile.js'
     #  Created file is added inside file explorer and file tabs
     And  I expect '[data-cy="file_newFile.js"]' appear 2 times on screen
     #  Created file's label is red
-    And  I expect ".file-status-untracked" appear 2 times on screen
+    And  I expect '.file-status-untracked' appear 2 times on screen
     And  I expect '[data-cy="file_newFile.js"].file-status-untracked' exists
     #  Root folder is expanded
     And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
@@ -52,17 +52,17 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     #  New tab is open with created file's label
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "newFile.js"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'newFile.js'
     #  Created file is added inside file explorer and file tabs
     And  I expect '[data-cy="file_terraform/newFile.js"]' appear 2 times on screen
     #  Created file's label is red
-    And  I expect ".file-status-untracked" appear 2 times on screen
+    And  I expect '.file-status-untracked' appear 2 times on screen
     And  I expect '[data-cy="file_terraform/newFile.js"].file-status-untracked' exists
     #  Parent folder is expanded
     And  I expect '[data-cy="file-explorer"] [data-cy="folder-icon_terraform"].fa-folder-open' exists
@@ -75,9 +75,9 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFolder'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Folder is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
@@ -96,9 +96,9 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFolder'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Folder is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen

--- a/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/create.file.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: create file and folder
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
@@ -28,8 +28,8 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     #  New active tab is open with created file's label
@@ -52,8 +52,8 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     #  New tab is open with created file's label
@@ -75,8 +75,8 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-menu-create-folder"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFolder"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open
@@ -96,8 +96,8 @@ Feature: Test modelizer text view: create file and folder
     When I click on '[data-cy="file-explorer-menu-create-folder"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "newFolder"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFolder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     #  No tab open

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -2,21 +2,21 @@ Feature: Test modelizer text view: delete file and folder
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
@@ -30,13 +30,13 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-explorer"] [data-cy="file_branch.txt.js"]' not exists
 
   Scenario: Delete last file of a sub-folder should not expand sub-folder
     Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
+    And   I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
 
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]'
@@ -46,18 +46,18 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
     And  I expect '[data-cy="folder-icon_terraform"].fa-folder' exists
   
   Scenario: Delete last file of a sub-folder should close active tab
     Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
+    And   I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
 
     When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'app.tf'
 
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]'
@@ -67,7 +67,7 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' not exists
@@ -77,8 +77,8 @@ Feature: Test modelizer text view: delete file and folder
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'branch.txt'
 
     When I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
@@ -88,10 +88,10 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is deleted."
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
 
   Scenario: Delete empty folder of the root folder should remove it from file explorer
     #  Create empty folder
@@ -100,9 +100,9 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'folder'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Folder is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-explorer"] [data-cy="folder_folder"]' appear 1 time on screen
 
@@ -115,7 +115,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' not exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is deleted."
+    Then I expect 'positive' toast to appear with text 'Folder is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="folder_folder"]' not exists
 
@@ -123,7 +123,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
     And  I double click on '[data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
 
     When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
@@ -139,11 +139,11 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is deleted."
+    Then I expect 'positive' toast to appear with text 'Folder is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check elements to delete are deleted, and elements to keep are still present
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="file_terraform"]' not exists
     And  I expect '[data-cy="file_app.tf"]' not exists
 
@@ -155,9 +155,9 @@ Feature: Test modelizer text view: delete file and folder
 
     When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'app.tf'
 
-    #  Create "folder" inside "terraform" folder
+    #  Create 'folder' inside 'terraform' folder
     When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
@@ -165,14 +165,14 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'folder'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Folder is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-explorer"] [data-cy="folder_terraform/folder"]' appear 1 time on screen
     And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder' exists
 
-    #  Create "file.js" inside "folder"
+    #  Create 'file.js' inside 'folder'
     When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
@@ -180,16 +180,16 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'file.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file_terraform/folder/file.js"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'file.js'
     And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder-open' exists
 
-    #  Delete "terraform" folder
+    #  Delete 'terraform' folder
     When I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
@@ -203,9 +203,9 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is deleted."
+    Then I expect 'positive' toast to appear with text 'Folder is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
-    #  Check "folder", "app.tf" and "file.js" are deleted and all tab closed
+    #  Check 'folder', 'app.tf' and 'file.js' are deleted and all tab closed
     And  I expect '[data-cy="file_terraform/folder/file.js"]' not exists
     And  I expect '[data-cy="file_terraform/app.tf"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
@@ -219,10 +219,10 @@ Feature: Test modelizer text view: delete file and folder
 
     When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'app.tf'
 
-    #  Create "folder" inside "terraform" folder
+    #  Create 'folder' inside 'terraform' folder
     When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
@@ -230,14 +230,14 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'folder'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'Folder is created &#129395;!'
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="folder_terraform/folder"]' appear 1 time on screen
     And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder' exists
 
-    #  Create "file.js" inside "folder"
+    #  Create 'file.js' inside 'folder'
     When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
@@ -245,18 +245,18 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'file.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "File is created &#129395;!"
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
 
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file_terraform/folder/file.js"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 3 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'file.js'
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' appear 2 times on screen
     And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder-open' exists
 
-    #  Delete "terraform" folder
+    #  Delete 'terraform' folder
     When I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
@@ -270,11 +270,11 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
     
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Folder is deleted."
+    Then I expect 'positive' toast to appear with text 'Folder is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
-    #  Check "folder", "app.tf" and "file.js" are deleted, related tabs closed and active tab is "README.md"
+    #  Check 'folder', 'app.tf' and 'file.js' are deleted, related tabs closed and active tab is 'README.md'
     And  I expect '[data-cy="file_terraform/folder/file.js"]' not exists
     And  I expect '[data-cy="file_terraform/app.tf"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="folder_terraform/folder"]' not exists

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -6,275 +6,275 @@ Feature: Test modelizer text view: delete file and folder
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: Delete a file of the root folder should remove it from file explorer
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-branch.txt.js\"]" not exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
 
   Scenario: Delete last file of a sub-folder should not expand sub-folder
-    Given I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-terraform\"]"
+    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-app.tf\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-app.tf\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-explorer-icon-{{ projectName }}\"].fa-folder-open" exists
-    And  I expect "[data-cy=\"file-explorer-icon-terraform\"].fa-folder" exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder' exists
   
   Scenario: Delete last file of a sub-folder should close active tab
-    Given I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-terraform\"]"
+    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
 
-    When I double click on "[data-cy=\"file-explorer-app.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "app.tf"
+    When I double click on '[data-cy="file-explorer-app.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-app.tf\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-app.tf\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" not exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' not exists
 
   Scenario: Open two files and delete the selected file should close corresponding active tab and select another active tab
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    And  I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    And  I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "File is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
 
   Scenario: Delete empty folder of the root folder should remove it from file explorer
     #  Create empty folder
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-{{ projectName }}\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
-    When I click on "[data-cy=\"file-explorer-menu-create-folder\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "folder"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
+    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-folder\"]" appear 1 time on screen
+    And  I expect '[data-cy="create-file-form"]' is closed
+    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
-    And  I expect "[data-cy=\"confirm-delete-checkbox\"]" not exists
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
+    And  I expect '[data-cy="confirm-delete-checkbox"]' not exists
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-folder\"]" not exists
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file-label-folder"]' not exists
 
   Scenario: Delete non-empty folder should display the checkox to confirm deletion of folder and its content (& keep selected tab open)
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
 
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
-    And  I expect "[data-cy=\"confirm-delete-checkbox\"]" exists
-    And  I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is not checked
-    And  I expect "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]" to be disabled
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
+    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
 
-    When I click on "[data-cy=\"confirm-delete-checkbox\"]"
-    Then I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is checked
+    When I click on '[data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
+    And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check elements to delete are deleted, and elements to keep are still present
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-terraform\"]" not exists
-    And  I expect "[data-cy=\"file-label-app.tf\"]" not exists
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-terraform"]' not exists
+    And  I expect '[data-cy="file-label-app.tf"]' not exists
 
 
   Scenario: Delete folder that contains opened files should remove all the corresponding tabs
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-app.tf\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
+    Then I expect '[data-cy="file-explorer-app.tf"]' exists
 
-    When I double click on "[data-cy=\"file-explorer-app.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "app.tf"
+    When I double click on '[data-cy="file-explorer-app.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
     #  Create "folder" inside "terraform" folder
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-folder\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "folder"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-folder\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-explorer-icon-folder\"].fa-folder" exists
+    And  I expect '[data-cy="create-file-form"]' is closed
+    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
+    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder' exists
 
     #  Create "file.js" inside "folder"
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "file.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "file.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-file.js\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "file.js"
-    And  I expect "[data-cy=\"file-explorer-icon-folder\"].fa-folder-open" exists
+    And  I expect '[data-cy="create-file-form"]' is closed
+    And  I expect '[data-cy="file-label-file.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
+    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder-open' exists
 
     #  Delete "terraform" folder
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
-    And  I expect "[data-cy=\"confirm-delete-checkbox\"]" exists
-    And  I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is not checked
-    And  I expect "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]" to be disabled
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
+    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
 
-    When I click on "[data-cy=\"confirm-delete-checkbox\"]"
-    Then I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is checked
+    When I click on '[data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
 
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
+    And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted and all tab closed
-    And  I expect "[data-cy=\"file-label-file.js\"]" not exists
-    And  I expect "[data-cy=\"file-label-app.tf\"]" not exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"file-label-folder\"]" not exists
+    And  I expect '[data-cy="file-label-file.js"]' not exists
+    And  I expect '[data-cy="file-label-app.tf"]' not exists
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
+    And  I expect '[data-cy="file-label-folder"]' not exists
 
   Scenario: Delete folder that contains opened files should remove all the corresponding tabs and select another active tab
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I double click on "[data-cy=\"file-explorer-README.md\"]"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-app.tf\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer-README.md"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
+    Then I expect '[data-cy="file-explorer-app.tf"]' exists
 
-    When I double click on "[data-cy=\"file-explorer-app.tf\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "app.tf"
+    When I double click on '[data-cy="file-explorer-app.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
     #  Create "folder" inside "terraform" folder
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-folder\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "folder"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-folder\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-explorer-icon-folder\"].fa-folder" exists
+    And  I expect '[data-cy="create-file-form"]' is closed
+    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
+    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder' exists
 
     #  Create "file.js" inside "folder"
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-folder\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-input\"]" text "file.js"
-    And  I click on "[data-cy=\"create-file-form\"] [data-cy=\"create-file-submit\"]"
+    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "file.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
 
-    And  I expect "[data-cy=\"create-file-form\"]" is closed
-    And  I expect "[data-cy=\"file-label-file.js\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 3 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "file.js"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-explorer-icon-folder\"].fa-folder-open" exists
+    And  I expect '[data-cy="create-file-form"]' is closed
+    And  I expect '[data-cy="file-label-file.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 3 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder-open' exists
 
     #  Delete "terraform" folder
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-terraform\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on "[data-cy=\"file-explorer-menu-delete-file\"]"
-    Then I expect "[data-cy=\"delete-file-dialog\"]" exists
-    And  I expect "[data-cy=\"confirm-delete-checkbox\"]" exists
-    And  I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is not checked
-    And  I expect "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]" to be disabled
+    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
+    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
 
-    When I click on "[data-cy=\"confirm-delete-checkbox\"]"
-    Then I expect checkbox "[data-cy=\"confirm-delete-checkbox\"]" is checked
+    When I click on '[data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
     
-    When I click on "[data-cy=\"delete-file-form\"] [data-cy=\"delete-file-submit\"]"
+    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
-    And  I expect "[data-cy=\"delete-file-form\"]" is closed
+    And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted, related tabs closed and active tab is "README.md"
-    And  I expect "[data-cy=\"file-label-file.js\"]" not exists
-    And  I expect "[data-cy=\"file-label-app.tf\"]" not exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-folder\"]" not exists
+    And  I expect '[data-cy="file-label-file.js"]' not exists
+    And  I expect '[data-cy="file-label-app.tf"]' not exists
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-folder"]' not exists

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: delete file and folder
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
@@ -29,7 +29,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
@@ -45,7 +45,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
@@ -66,7 +66,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
@@ -87,7 +87,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
@@ -100,8 +100,8 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     When I click on '[data-cy="file-explorer-menu-create-folder"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
@@ -112,9 +112,9 @@ Feature: Test modelizer text view: delete file and folder
 
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
-    And  I expect '[data-cy="confirm-delete-checkbox"]' not exists
+    And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' not exists
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     And  I expect '[data-cy="file-label-folder"]' not exists
@@ -131,14 +131,14 @@ Feature: Test modelizer text view: delete file and folder
 
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
-    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
-    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
-    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
+    And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="submit-button"]' to be disabled
 
-    When I click on '[data-cy="confirm-delete-checkbox"]'
-    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
+    When I click on '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check elements to delete are deleted, and elements to keep are still present
@@ -165,8 +165,8 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-create-folder"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
@@ -180,8 +180,8 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "file.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-label-file.js"]' appear 2 times on screen
@@ -195,14 +195,14 @@ Feature: Test modelizer text view: delete file and folder
 
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
-    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
-    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
-    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
+    And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="submit-button"]' to be disabled
 
-    When I click on '[data-cy="confirm-delete-checkbox"]'
-    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
+    When I click on '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
 
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted and all tab closed
@@ -230,8 +230,8 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-create-folder"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "folder"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
     And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
@@ -245,8 +245,8 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="create-file-input"]' text "file.js"
-    And  I click on '[data-cy="create-file-form"] [data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
 
     And  I expect '[data-cy="create-file-form"]' is closed
@@ -262,14 +262,14 @@ Feature: Test modelizer text view: delete file and folder
 
     When I click on '[data-cy="file-explorer-menu-delete-file"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
-    And  I expect '[data-cy="confirm-delete-checkbox"]' exists
-    And  I expect checkbox '[data-cy="confirm-delete-checkbox"]' is not checked
-    And  I expect '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]' to be disabled
+    And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
+    And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked
+    And  I expect '[data-cy="delete-file-form"] [data-cy="submit-button"]' to be disabled
 
-    When I click on '[data-cy="confirm-delete-checkbox"]'
-    Then I expect checkbox '[data-cy="confirm-delete-checkbox"]' is checked
+    When I click on '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]'
+    Then I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is checked
     
-    When I click on '[data-cy="delete-file-form"] [data-cy="delete-file-submit"]'
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted, related tabs closed and active tab is "README.md"

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: delete file and folder
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -17,13 +17,13 @@ Feature: Test modelizer text view: delete file and folder
     And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
 
   Scenario: Delete a file of the root folder should remove it from file explorer
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -32,14 +32,14 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file-label-branch.txt.js"]' not exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="file_branch.txt.js"]' not exists
 
   Scenario: Delete last file of a sub-folder should not expand sub-folder
-    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
+    Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -48,19 +48,19 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file-explorer-icon-{{ projectName }}"].fa-folder-open' exists
-    And  I expect '[data-cy="file-explorer-icon-terraform"].fa-folder' exists
+    And  I expect '[data-cy="folder-icon_{{ projectName }}"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_terraform"].fa-folder' exists
   
   Scenario: Delete last file of a sub-folder should close active tab
-    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
+    Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
 
-    When I double click on '[data-cy="file-explorer-app.tf"]'
+    When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_terraform/app.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -73,15 +73,15 @@ Feature: Test modelizer text view: delete file and folder
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' not exists
 
   Scenario: Open two files and delete the selected file should close corresponding active tab and select another active tab
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I double click on '[data-cy="file-explorer-branch.txt"]'
-    And  I double click on '[data-cy="file-explorer-README.md"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -95,8 +95,8 @@ Feature: Test modelizer text view: delete file and folder
 
   Scenario: Delete empty folder of the root folder should remove it from file explorer
     #  Create empty folder
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
@@ -104,10 +104,10 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_folder"]' appear 1 time on screen
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -117,16 +117,16 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file-label-folder"]' not exists
+    And  I expect '[data-cy="folder_folder"]' not exists
 
   Scenario: Delete non-empty folder should display the checkox to confirm deletion of folder and its content (& keep selected tab open)
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I double click on '[data-cy="file-explorer-README.md"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I double click on '[data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -144,22 +144,22 @@ Feature: Test modelizer text view: delete file and folder
     #  Check elements to delete are deleted, and elements to keep are still present
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-terraform"]' not exists
-    And  I expect '[data-cy="file-label-app.tf"]' not exists
+    And  I expect '[data-cy="file_terraform"]' not exists
+    And  I expect '[data-cy="file_app.tf"]' not exists
 
 
   Scenario: Delete folder that contains opened files should remove all the corresponding tabs
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
-    Then I expect '[data-cy="file-explorer-app.tf"]' exists
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
+    Then I expect '[data-cy="file-explorer"] [data-cy="file_terraform/app.tf"]' exists
 
-    When I double click on '[data-cy="file-explorer-app.tf"]'
+    When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
     #  Create "folder" inside "terraform" folder
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
@@ -169,12 +169,12 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
-    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder' exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_terraform/folder"]' appear 1 time on screen
+    And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder' exists
 
     #  Create "file.js" inside "folder"
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -184,13 +184,13 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect '[data-cy="file-label-file.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file_terraform/folder/file.js"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
-    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder-open' exists
 
     #  Delete "terraform" folder
-    When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -206,25 +206,25 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted and all tab closed
-    And  I expect '[data-cy="file-label-file.js"]' not exists
-    And  I expect '[data-cy="file-label-app.tf"]' not exists
+    And  I expect '[data-cy="file_terraform/folder/file.js"]' not exists
+    And  I expect '[data-cy="file_terraform/app.tf"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
-    And  I expect '[data-cy="file-label-folder"]' not exists
+    And  I expect '[data-cy="folder_terraform/folder"]' not exists
 
   Scenario: Delete folder that contains opened files should remove all the corresponding tabs and select another active tab
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I double click on '[data-cy="file-explorer-README.md"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
-    Then I expect '[data-cy="file-explorer-app.tf"]' exists
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
+    Then I expect '[data-cy="file_terraform/app.tf"]' exists
 
-    When I double click on '[data-cy="file-explorer-app.tf"]'
+    When I double click on '[data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
 
     #  Create "folder" inside "terraform" folder
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
@@ -234,12 +234,12 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Folder is created &#129395;!"
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect '[data-cy="file-label-folder"]' appear 1 time on screen
-    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder' exists
+    And  I expect '[data-cy="folder_terraform/folder"]' appear 1 time on screen
+    And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder' exists
 
     #  Create "file.js" inside "folder"
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform/folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
@@ -250,14 +250,14 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect "positive" toast to appear with text "File is created &#129395;!"
 
     And  I expect '[data-cy="create-file-form"]' is closed
-    And  I expect '[data-cy="file-label-file.js"]' appear 2 times on screen
+    And  I expect '[data-cy="file_terraform/folder/file.js"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 3 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "file.js"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-explorer-icon-folder"].fa-folder-open' exists
+    And  I expect '[data-cy="folder-icon_terraform/folder"].fa-folder-open' exists
 
     #  Delete "terraform" folder
-    When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder-button_terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -273,8 +273,8 @@ Feature: Test modelizer text view: delete file and folder
     Then I expect "positive" toast to appear with text "Folder is deleted."
     And  I expect '[data-cy="delete-file-form"]' is closed
     #  Check "folder", "app.tf" and "file.js" are deleted, related tabs closed and active tab is "README.md"
-    And  I expect '[data-cy="file-label-file.js"]' not exists
-    And  I expect '[data-cy="file-label-app.tf"]' not exists
+    And  I expect '[data-cy="file_terraform/folder/file.js"]' not exists
+    And  I expect '[data-cy="file_terraform/app.tf"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-folder"]' not exists
+    And  I expect '[data-cy="folder_terraform/folder"]' not exists

--- a/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/delete.file.feature
@@ -26,7 +26,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
@@ -42,7 +42,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
@@ -63,7 +63,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-app.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
@@ -84,7 +84,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
 
     When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
@@ -98,7 +98,7 @@ Feature: Test modelizer text view: delete file and folder
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-{{ projectName }}"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
-    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
@@ -110,7 +110,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
     And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' not exists
 
@@ -129,7 +129,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
     And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
     And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked
@@ -162,7 +162,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
@@ -177,7 +177,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
@@ -193,7 +193,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
     And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
     And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked
@@ -227,7 +227,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-folder"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-folder-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "folder"
@@ -242,7 +242,7 @@ Feature: Test modelizer text view: delete file and folder
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-folder"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-create-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "file.js"
@@ -260,7 +260,7 @@ Feature: Test modelizer text view: delete file and folder
     When I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-terraform"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
-    When I click on '[data-cy="file-explorer-menu-delete-file"]'
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
     Then I expect '[data-cy="delete-file-dialog"]' exists
     And  I expect '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' exists
     And  I expect checkbox '[data-cy="delete-file-form"] [data-cy="confirm-delete-checkbox"]' is not checked

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -36,7 +36,7 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
 
-    When I click on '[data-cy="active-tab"] [data-cy="close-file-tab"]'
+    When I click on '[data-cy="active-tab"] [data-cy="close-button"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' not exists
     And  I expect '[data-cy="monaco-editor"]' not exists
@@ -45,41 +45,41 @@ Feature: Test modelizer text view: open file
     When I double click on '[data-cy="file-explorer-README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tab-content-README.md"]' exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I double click on '[data-cy="file-explorer-branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
     And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
-    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
     When I click on '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open two files then click on the inactive file, its corresponding tab should switch and become active tab
     When I double click on '[data-cy="file-explorer-README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tab-content-README.md"]' exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I double click on '[data-cy="file-explorer-branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
     And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
-    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
     When I double click on '[data-cy="file-explorer-README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open two files and click to close the active tab, the other opened tab becomes the active tab
     When I double click on '[data-cy="file-explorer-README.md"]'
@@ -88,20 +88,20 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
     And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
-    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
-    When I click on '[data-cy="active-tab"] [data-cy="close-file-tab"]'
+    When I click on '[data-cy="active-tab"] [data-cy="close-button"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tab-content-README.md"]' exists
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' exists
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open a file and checkout branch, the file should reload if its content has changed
     When I double click on '[data-cy="file-explorer-branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
@@ -109,38 +109,38 @@ Feature: Test modelizer text view: open file
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
 
   Scenario: Open two files, checkout branch and if an opened file no longer exists, its corresponding tab should be closed
     When I double click on '[data-cy="file-explorer-README.md"]'
     And  I double click on '[data-cy="file-explorer-branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
 
   Scenario: Open two files and checkout branch, then the active tab is closed, the other opened tab becomes the active tab
     When I double click on '[data-cy="file-explorer-branch.txt"]'
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
     Then I double click on '[data-cy="file-explorer-README.md"]'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-README.md"]' exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -2,6 +2,7 @@ Feature: Test modelizer text view: open file
 
   Background:
     Given I clear cache
+    And  I set viewport size to "1536" px for width and "960" px for height
     And  I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
     And  I set context field "projectName" with "leto-modelizer-project-test"
     And  I visit the "/"
@@ -17,20 +18,20 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
 
   Scenario: Double click on a file should open a tab
-    When I double click on '[data-cy="file-explorer-README.md"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs"]' exists
     And  I expect '[data-cy="monaco-editor"]' exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-README.md"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_README.md"]' is "README.md"
 
   Scenario: Open a file and click to close the active tab should display nothing on the file tabs
-    When I double click on '[data-cy="file-explorer-README.md"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs"]' exists
     And  I expect '[data-cy="monaco-editor"]' exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
@@ -42,16 +43,16 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="monaco-editor"]' not exists
 
   Scenario: Open two files then click on the inactive tab, it should switch and become active tab
-    When I double click on '[data-cy="file-explorer-README.md"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
-    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file_branch.txt"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
@@ -62,32 +63,32 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open two files then click on the inactive file, its corresponding tab should switch and become active tab
-    When I double click on '[data-cy="file-explorer-README.md"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
-    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
-    When I double click on '[data-cy="file-explorer-README.md"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open two files and click to close the active tab, the other opened tab becomes the active tab
-    When I double click on '[data-cy="file-explorer-README.md"]'
-    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
@@ -97,8 +98,8 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
-  Scenario: Open a file and checkout branch, the file should reload if its content has changed
-    When I double click on '[data-cy="file-explorer-branch.txt"]'
+  Scenario: Open a file and checkout branch, the file should reload if its panel has changed
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
@@ -112,8 +113,8 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
 
   Scenario: Open two files, checkout branch and if an opened file no longer exists, its corresponding tab should be closed
-    When I double click on '[data-cy="file-explorer-README.md"]'
-    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
@@ -128,9 +129,9 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
 
   Scenario: Open two files and checkout branch, then the active tab is closed, the other opened tab becomes the active tab
-    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
-    Then I double click on '[data-cy="file-explorer-README.md"]'
+    Then I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: open file
     And  I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: open file
     And  I set context field "projectName" with "leto-modelizer-project-test"
     And  I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -103,10 +103,10 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
 
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
-    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
@@ -118,10 +118,10 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
 
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
-    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-content-README.md"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
@@ -136,10 +136,10 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
     And  I expect '[data-cy="file-tab-content-README.md"]' exists
 
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
-    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-content-README.md"]' not exists
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -104,8 +104,8 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
 
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
-    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
@@ -119,8 +119,8 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
 
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
-    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
@@ -137,8 +137,8 @@ Feature: Test modelizer text view: open file
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
-    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -2,22 +2,22 @@ Feature: Test modelizer text view: open file
 
   Background:
     Given I clear cache
-    And  I set viewport size to "1536" px for width and "960" px for height
-    And  I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And  I set context field "projectName" with "leto-modelizer-project-test"
-    And  I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 2 seconds
     And  I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
@@ -27,15 +27,15 @@ Feature: Test modelizer text view: open file
     Then I expect '[data-cy="file-tabs"]' exists
     And  I expect '[data-cy="monaco-editor"]' exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_README.md"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_README.md"]' is 'README.md'
 
   Scenario: Open a file and click to close the active tab should display nothing on the file tabs
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs"]' exists
     And  I expect '[data-cy="monaco-editor"]' exists
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
 
     When I click on '[data-cy="active-tab"] [data-cy="close-button"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
@@ -45,40 +45,40 @@ Feature: Test modelizer text view: open file
   Scenario: Open two files then click on the inactive tab, it should switch and become active tab
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file_branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'README.md'
+    And  I expect '[data-cy="file_branch.txt"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
     When I click on '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'branch.txt'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open two files then click on the inactive file, its corresponding tab should switch and become active tab
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'branch.txt'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
@@ -86,62 +86,62 @@ Feature: Test modelizer text view: open file
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
 
     When I click on '[data-cy="active-tab"] [data-cy="close-button"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
     And  I expect '[data-cy="file-tab-panel_branch.txt"]' not exists
 
   Scenario: Open a file and checkout branch, the file should reload if its panel has changed
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
     And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
-    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is 'test/remote'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'test/remote'
 
   Scenario: Open two files, checkout branch and if an opened file no longer exists, its corresponding tab should be closed
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
     And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
-    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is 'test/remote'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'test/remote'
 
   Scenario: Open two files and checkout branch, then the active tab is closed, the other opened tab becomes the active tab
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'main'
     Then I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'branch.txt'
     And  I expect '[data-cy="file-tab-panel_README.md"]' exists
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote"]'
     And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote"]'
-    Then I expect '[data-cy="git-current-branch-button"]' is "test/remote"
+    Then I expect '[data-cy="git-current-branch-button"]' is 'test/remote'
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tab-panel_README.md"]' not exists
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect '[data-cy="file-tab-panel_branch.txt"]' is 'test/remote'

--- a/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/open.file.feature
@@ -6,141 +6,141 @@ Feature: Test modelizer text view: open file
     And  I set context field "projectName" with "leto-modelizer-project-test"
     And  I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 2 seconds
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
 
   Scenario: Double click on a file should open a tab
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs\"]" exists
-    And  I expect "[data-cy=\"monaco-editor\"]" exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-README.md\"]" is "README.md"
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs"]' exists
+    And  I expect '[data-cy="monaco-editor"]' exists
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-README.md"]' is "README.md"
 
   Scenario: Open a file and click to close the active tab should display nothing on the file tabs
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs\"]" exists
-    And  I expect "[data-cy=\"monaco-editor\"]" exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs"]' exists
+    And  I expect '[data-cy="monaco-editor"]' exists
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
 
-    When I click on "[data-cy=\"active-tab\"] [data-cy=\"close-file-tab\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" not exists
-    And  I expect "[data-cy=\"monaco-editor\"]" not exists
+    When I click on '[data-cy="active-tab"] [data-cy="close-file-tab"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 0 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' not exists
+    And  I expect '[data-cy="monaco-editor"]' not exists
 
   Scenario: Open two files then click on the inactive tab, it should switch and become active tab
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tab-content-README.md"]' exists
 
-    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-branch.txt\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
 
-    When I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" not exists
+    When I click on '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
 
   Scenario: Open two files then click on the inactive file, its corresponding tab should switch and become active tab
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tab-content-README.md"]' exists
 
-    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-branch.txt\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
 
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" not exists
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
 
   Scenario: Open two files and click to close the active tab, the other opened tab becomes the active tab
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-label-branch.txt\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
+    And  I expect '[data-cy="file-label-branch.txt"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
 
-    When I click on "[data-cy=\"active-tab\"] [data-cy=\"close-file-tab\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" not exists
+    When I click on '[data-cy="active-tab"] [data-cy="close-file-tab"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tab-content-README.md"]' exists
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' not exists
 
   Scenario: Open a file and checkout branch, the file should reload if its content has changed
-    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
+    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
 
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-branch-remote-test/remote\"]"
-    And  I click on "[data-cy=\"git-menu-branch-checkout-test/remote\"]"
-    Then I expect "[data-cy=\"git-current-branch\"]" is "test/remote"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
+    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
 
   Scenario: Open two files, checkout branch and if an opened file no longer exists, its corresponding tab should be closed
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
 
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-branch-remote-test/remote\"]"
-    And  I click on "[data-cy=\"git-menu-branch-checkout-test/remote\"]"
-    Then I expect "[data-cy=\"git-current-branch\"]" is "test/remote"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
+    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"
 
   Scenario: Open two files and checkout branch, then the active tab is closed, the other opened tab becomes the active tab
-    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "main"
-    Then I double click on "[data-cy=\"file-explorer-README.md\"]"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" exists
+    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "main"
+    Then I double click on '[data-cy="file-explorer-README.md"]'
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-README.md"]' exists
 
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-branch-remote-test/remote\"]"
-    And  I click on "[data-cy=\"git-menu-branch-checkout-test/remote\"]"
-    Then I expect "[data-cy=\"git-current-branch\"]" is "test/remote"
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tab-content-README.md\"]" not exists
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-tab-content-branch.txt\"]" is "test/remote"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-remote-test/remote"]'
+    And  I click on '[data-cy="git-menu-branch-checkout-test/remote"]'
+    Then I expect '[data-cy="git-current-branch"]' is "test/remote"
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tab-content-README.md"]' not exists
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tab-content-branch.txt"]' is "test/remote"

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: update file's content
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: update file's content
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -1,68 +1,70 @@
-Feature: Test modelizer text view: update file's content
+Feature: Test modelizer text view: update file content
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
+    And  I expect current url is '/modelizer/{{ projectName }}/model'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
 
-    When I visit the "/#/modelizer/{{projectName}}/text"
+    When I visit the '/#/modelizer/{{projectName}}/text'
     Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 1 second
 
-  Scenario: Check if the file's content is set after being updated
+  Scenario: Check if the file content is set after being updated
     Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect active file content to contain "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect active file content to contain 'main'
 
-    When I set active file content to "updated content"
-    Then I expect active file content to contain "updated.*content"
+    When I set active file content to 'updated content'
+    Then I expect active file content to contain 'updated.*content'
 
   Scenario: Check if the file updated content is still set after switching tab
     Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+
     When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
     And  I expect '[data-cy="file_README.md"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect active file content to contain "main"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'README.md'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect active file content to contain 'main'
 
-    When I set active file content to "updated content"
-    Then I expect active file content to contain "updated.*content"
+    When I set active file content to 'updated content'
+    Then I expect active file content to contain 'updated.*content'
 
     When I click on '[data-cy="file-tabs-container"] [data-cy="file_README.md"]'
     And  I wait 1 second
     And  I click on '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]'
     And  I wait 1 second
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect active file content to contain "updated.*content"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
+    And  I expect active file content to contain 'updated.*content'
 
   Scenario: Open a file in root folder and update its content should change the file's class
     When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'branch.txt'
     And  I expect '[data-cy="file_branch.txt"].file-status-unmodified' exists
-    And  I expect active file content to contain "main"
+    And  I expect active file content to contain 'main'
 
-    When I set active file content to "updated content"
-    Then I expect active file content to contain "updated.*content"
+    When I set active file content to 'updated content'
+    Then I expect active file content to contain 'updated.*content'
     And  I expect '[data-cy="file_branch.txt"].file-status-modified' exists
 
   Scenario: Open a file in sub-folder and update its content should change the file's class
@@ -71,15 +73,15 @@ Feature: Test modelizer text view: update file's content
     And  I double click on '[data-cy="file-explorer"] [data-cy="file_terraform/app.tf"]'
     Then I expect '[data-cy="file_terraform/app.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'app.tf'
     And  I expect '[data-cy="file_terraform/app.tf"].file-status-unmodified' exists
-    And  I expect active file content to contain "main"
+    And  I expect active file content to contain 'main'
 
-    When I set active file content to "updated content"
+    When I set active file content to 'updated content'
     Then I expect '[data-cy="file_terraform/app.tf"].file-status-modified' exists
-    And  I expect active file content to contain "updated.*content"
+    And  I expect active file content to contain 'updated.*content'
 
-  Scenario: Update a file's content should make the "add" action available inside file explorer menu
+  Scenario: Update a file's content should make the 'add' action available inside file explorer menu
     When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
     And  I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
@@ -88,12 +90,12 @@ Feature: Test modelizer text view: update file's content
     And  I expect '[data-cy="file_branch.txt"].file-status-unmodified' exists
 
     When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
-    Then I expect active file content to contain "main"
+    Then I expect active file content to contain 'main'
 
-    When I set active file content to "updated content"
+    When I set active file content to 'updated content'
     And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     And  I wait 1 second
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     And  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' exists
     And  I expect '[data-cy="file_branch.txt"].file-status-modified' exists
-    And  I expect active file content to contain "updated.*content"
+    And  I expect active file content to contain 'updated.*content'

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -17,13 +17,13 @@ Feature: Test modelizer text view: update file's content
     And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' exists
     And  I wait 1 second
 
   Scenario: Check if the file's content is set after being updated
-    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    When I double click on '[data-cy="file-explorer-branch.txt"]'
-    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
+    Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
+    Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect active file content to contain "main"
@@ -32,11 +32,11 @@ Feature: Test modelizer text view: update file's content
     Then I expect active file content to contain "updated.*content"
 
   Scenario: Check if the file updated content is still set after switching tab
-    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    When I double click on '[data-cy="file-explorer-README.md"]'
-    And  I double click on '[data-cy="file-explorer-branch.txt"]'
-    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
-    And  I expect '[data-cy="file-label-README.md"]' appear 2 times on screen
+    Given I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_README.md"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
+    Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
+    And  I expect '[data-cy="file_README.md"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
@@ -45,55 +45,55 @@ Feature: Test modelizer text view: update file's content
     When I set active file content to "updated content"
     Then I expect active file content to contain "updated.*content"
 
-    When I click on '[data-cy="file-tabs-container"] [data-cy="file-label-README.md"]'
+    When I click on '[data-cy="file-tabs-container"] [data-cy="file_README.md"]'
     And  I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-branch.txt"]'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_branch.txt"]'
     And  I wait 1 second
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect active file content to contain "updated.*content"
 
   Scenario: Open a file in root folder and update its content should change the file's class
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I double click on '[data-cy="file-explorer-branch.txt"]'
-    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
+    Then I expect '[data-cy="file_branch.txt"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
-    And  I expect '[data-cy="file-label-branch.txt"].file-status-unmodified' exists
+    And  I expect '[data-cy="file_branch.txt"].file-status-unmodified' exists
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
     Then I expect active file content to contain "updated.*content"
-    And  I expect '[data-cy="file-label-branch.txt"].file-status-modified' exists
+    And  I expect '[data-cy="file_branch.txt"].file-status-modified' exists
 
   Scenario: Open a file in sub-folder and update its content should change the file's class
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
-    And  I double click on '[data-cy="file-explorer-app.tf"]'
-    Then I expect '[data-cy="file-label-app.tf"]' appear 2 times on screen
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder_terraform"]'
+    And  I double click on '[data-cy="file-explorer"] [data-cy="file_terraform/app.tf"]'
+    Then I expect '[data-cy="file_terraform/app.tf"]' appear 2 times on screen
     And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
-    And  I expect '[data-cy="file-label-app.tf"].file-status-unmodified' exists
+    And  I expect '[data-cy="file_terraform/app.tf"].file-status-unmodified' exists
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
-    Then I expect '[data-cy="file-label-app.tf"].file-status-modified' exists
+    Then I expect '[data-cy="file_terraform/app.tf"].file-status-modified' exists
     And  I expect active file content to contain "updated.*content"
 
   Scenario: Update a file's content should make the "add" action available inside file explorer menu
-    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
-    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    When I click on '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     And  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' not exists
-    And  I expect '[data-cy="file-label-branch.txt"].file-status-unmodified' exists
+    And  I expect '[data-cy="file_branch.txt"].file-status-unmodified' exists
 
-    When I double click on '[data-cy="file-explorer"] [data-cy="file-label-branch.txt"]'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_branch.txt"]'
     Then I expect active file content to contain "main"
 
     When I set active file content to "updated content"
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_branch.txt"]'
     And  I wait 1 second
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
     And  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' exists
-    And  I expect '[data-cy="file-label-branch.txt"].file-status-modified' exists
+    And  I expect '[data-cy="file_branch.txt"].file-status-modified' exists
     And  I expect active file content to contain "updated.*content"

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -6,94 +6,94 @@ Feature: Test modelizer text view: update file's content
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And  I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And  I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And  I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I expect '[data-cy="import-project-form"]' is closed
     And  I expect current url is "modelizer/{{ projectName }}/model"
-    And  I expect "[data-cy=\"project-name\"]" is "{{ projectName }}"
+    And  I expect '[data-cy="project-name"]' is "{{ projectName }}"
 
     When I visit the "/#/modelizer/{{projectName}}/text"
-    Then I expect "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]" exists
+    Then I expect '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]' exists
     And  I wait 1 second
 
   Scenario: Check if the file's content is set after being updated
-    Given I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    When I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-label-branch.txt\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    When I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
     Then I expect active file content to contain "updated.*content"
 
   Scenario: Check if the file updated content is still set after switching tab
-    Given I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    When I double click on "[data-cy=\"file-explorer-README.md\"]"
-    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-label-branch.txt\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-label-README.md\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"inactive-tab\"]" is "README.md"
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    Given I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    When I double click on '[data-cy="file-explorer-README.md"]'
+    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
+    And  I expect '[data-cy="file-label-README.md"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is "README.md"
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
     Then I expect active file content to contain "updated.*content"
 
-    When I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-README.md\"]"
+    When I click on '[data-cy="file-tabs-container"] [data-cy="file-label-README.md"]'
     And  I wait 1 second
-    And  I click on "[data-cy=\"file-tabs-container\"] [data-cy=\"file-label-branch.txt\"]"
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file-label-branch.txt"]'
     And  I wait 1 second
-    Then I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
     And  I expect active file content to contain "updated.*content"
 
   Scenario: Open a file in root folder and update its content should change the file's class
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I double click on "[data-cy=\"file-explorer-branch.txt\"]"
-    Then I expect "[data-cy=\"file-label-branch.txt\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "branch.txt"
-    And  I expect "[data-cy=\"file-label-branch.txt\"].file-status-unmodified" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I double click on '[data-cy="file-explorer-branch.txt"]'
+    Then I expect '[data-cy="file-label-branch.txt"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "branch.txt"
+    And  I expect '[data-cy="file-label-branch.txt"].file-status-unmodified' exists
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
     Then I expect active file content to contain "updated.*content"
-    And  I expect "[data-cy=\"file-label-branch.txt\"].file-status-modified" exists
+    And  I expect '[data-cy="file-label-branch.txt"].file-status-modified' exists
 
   Scenario: Open a file in sub-folder and update its content should change the file's class
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-terraform\"]"
-    And  I double click on "[data-cy=\"file-explorer-app.tf\"]"
-    Then I expect "[data-cy=\"file-label-app.tf\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [role=\"tab\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"file-tabs-container\"] [data-cy=\"active-tab\"]" is "app.tf"
-    And  I expect "[data-cy=\"file-label-app.tf\"].file-status-unmodified" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-label-terraform"]'
+    And  I double click on '[data-cy="file-explorer-app.tf"]'
+    Then I expect '[data-cy="file-label-app.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [role="tab"]' appear 1 time on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is "app.tf"
+    And  I expect '[data-cy="file-label-app.tf"].file-status-unmodified' exists
     And  I expect active file content to contain "main"
 
     When I set active file content to "updated content"
-    Then I expect "[data-cy=\"file-label-app.tf\"].file-status-modified" exists
+    Then I expect '[data-cy="file-label-app.tf"].file-status-modified' exists
     And  I expect active file content to contain "updated.*content"
 
   Scenario: Update a file's content should make the "add" action available inside file explorer menu
-    When I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-{{ projectName }}\"]"
-    And  I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]"
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
-    And  I expect "[data-cy=\"file-explorer-menu-add-file\"]" not exists
-    And  I expect "[data-cy=\"file-label-branch.txt\"].file-status-unmodified" exists
+    When I click on '[data-cy="file-explorer"] [data-cy="file-label-{{ projectName }}"]'
+    And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
+    And  I expect '[data-cy="file-explorer-menu-add-file"]' not exists
+    And  I expect '[data-cy="file-label-branch.txt"].file-status-unmodified' exists
 
-    When I double click on "[data-cy=\"file-explorer\"] [data-cy=\"file-label-branch.txt\"]"
+    When I double click on '[data-cy="file-explorer"] [data-cy="file-label-branch.txt"]'
     Then I expect active file content to contain "main"
 
     When I set active file content to "updated content"
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-branch.txt\"]"
-    And I wait 1 second
-    Then I expect "[data-cy=\"file-explorer-action-menu\"]" exists
-    And  I expect "[data-cy=\"file-explorer-menu-add-file\"]" exists
-    And  I expect "[data-cy=\"file-label-branch.txt\"].file-status-modified" exists
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
+    And  I wait 1 second
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
+    And  I expect '[data-cy="file-explorer-menu-add-file"]' exists
+    And  I expect '[data-cy="file-label-branch.txt"].file-status-modified' exists
     And  I expect active file content to contain "updated.*content"

--- a/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/update.file.feature
@@ -84,7 +84,7 @@ Feature: Test modelizer text view: update file's content
     And  I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
-    And  I expect '[data-cy="file-explorer-menu-add-file"]' not exists
+    And  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' not exists
     And  I expect '[data-cy="file-label-branch.txt"].file-status-unmodified' exists
 
     When I double click on '[data-cy="file-explorer"] [data-cy="file-label-branch.txt"]'
@@ -94,6 +94,6 @@ Feature: Test modelizer text view: update file's content
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-branch.txt"]'
     And  I wait 1 second
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
-    And  I expect '[data-cy="file-explorer-menu-add-file"]' exists
+    And  I expect '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]' exists
     And  I expect '[data-cy="file-label-branch.txt"].file-status-modified' exists
     And  I expect active file content to contain "updated.*content"

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -17,8 +17,8 @@ Feature: Test modelizer text view: change git branch
 
 
   Scenario: Checkout action should change current branch
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
     And  I click on '[data-cy="git-menu-branch-checkout-test/remote1"]'
     Then I expect '[data-cy="git-menu-branch-checkout-loader-test/remote1"]' not exists
-    And  I expect '[data-cy="git-current-branch"]' is "test/remote1"
+    And  I expect '[data-cy="git-current-branch-button"]' is "test/remote1"

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -6,19 +6,19 @@ Feature: Test modelizer text view: change git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
-    And I visit the "/#/modelizer/{{projectName}}/text"
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I visit the "/#/modelizer/{{projectName}}/text"
 
 
   Scenario: Checkout action should change current branch
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-branch-remote-test/remote1\"]"
-    And I click on "[data-cy=\"git-menu-branch-checkout-test/remote1\"]"
-    Then I expect "[data-cy=\"git-menu-branch-checkout-loader-test/remote1\"]" not exists
-    And I expect "[data-cy=\"git-current-branch\"] " is "test/remote1"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
+    And  I click on '[data-cy="git-menu-branch-checkout-test/remote1"]'
+    Then I expect '[data-cy="git-menu-branch-checkout-loader-test/remote1"]' not exists
+    And  I expect '[data-cy="git-current-branch"]' is "test/remote1"

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: change git branch
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I visit the "/#/modelizer/{{projectName}}/text"

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: change git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -2,18 +2,18 @@ Feature: Test modelizer text view: change git branch
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I visit the "/#/modelizer/{{projectName}}/text"
+    And  I visit the '/#/modelizer/{{projectName}}/text'
 
 
   Scenario: Checkout action should change current branch
@@ -21,4 +21,4 @@ Feature: Test modelizer text view: change git branch
     And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote1"]'
     And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote1"]'
     Then I expect '[data-cy="git-branch-action-menu"] [data-cy="checkout-loader_test/remote1"]' not exists
-    And  I expect '[data-cy="git-current-branch-button"]' is "test/remote1"
+    And  I expect '[data-cy="git-current-branch-button"]' is 'test/remote1'

--- a/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/change.branch.feature
@@ -18,7 +18,7 @@ Feature: Test modelizer text view: change git branch
 
   Scenario: Checkout action should change current branch
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
-    And  I click on '[data-cy="git-menu-branch-checkout-test/remote1"]'
-    Then I expect '[data-cy="git-menu-branch-checkout-loader-test/remote1"]' not exists
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote1"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="checkout_test/remote1"]'
+    Then I expect '[data-cy="git-branch-action-menu"] [data-cy="checkout-loader_test/remote1"]' not exists
     And  I expect '[data-cy="git-current-branch-button"]' is "test/remote1"

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -7,9 +7,9 @@ Feature: Test modelizer text view: git commit
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    And  I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -13,7 +13,7 @@ Feature: Test modelizer text view: git commit
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    And  I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-current-branch-button"]'
     And  I wait 1 second
     Then I expect '[data-cy="git-menu-commit"]' exists
 
@@ -48,7 +48,7 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Commit
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-commit"]' exists
 
     When I click on '[data-cy="git-menu-commit"]'
@@ -63,7 +63,7 @@ Feature: Test modelizer text view: git commit
 
     #  New commit message is not added inside list of logs
     When I click on '[data-cy="close-dialog-button"]'
-    And  I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
@@ -95,7 +95,7 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Commit
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-commit"]' exists
 
     When I click on '[data-cy="git-menu-commit"]'
@@ -110,7 +110,7 @@ Feature: Test modelizer text view: git commit
     And  I expect "positive" toast to appear with text "Your files are committed &#129395;!"
 
     #  New commit message is added inside list of logs
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -20,16 +20,16 @@ Feature: Test modelizer text view: git commit
   Scenario: Commit with no change
     When I click on '[data-cy="git-menu-commit"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
-    And  I expect '[data-cy="git-commit-empty-item"]' exists
+    And  I expect '[data-cy="git-commit-dialog"] [data-cy="empty-item"]' exists
 
   Scenario: Commit an added file without commit message fails
     #  Check list of logs
     When I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
-    And  I expect '[data-cy="git-log-list"]' exists
-    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
 
-    When I click on '[data-cy="dialog-icon-close"]'
+    When I click on '[data-cy="close-dialog-button"]'
     Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
@@ -53,8 +53,8 @@ Feature: Test modelizer text view: git commit
 
     When I click on '[data-cy="git-menu-commit"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
-    And  I expect '[data-cy="git-commit-staged-item"]' exists
-    And  I expect '[data-cy="git-commit-staged-item-file"]' appear 1 time on screen
+    And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-title"]' exists
+    And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
 
     #  Empty commit message displays an error
     When I click on '[data-cy="git-form-submit"]'
@@ -62,21 +62,21 @@ Feature: Test modelizer text view: git commit
     And  I expect '[data-cy="git-commit-form"] [role="alert"]' is "Please type something"
 
     #  New commit message is not added inside list of logs
-    When I click on '[data-cy="dialog-icon-close"]'
+    When I click on '[data-cy="close-dialog-button"]'
     And  I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
-    And  I expect '[data-cy="git-log-list"]' exists
-    And  I expect '[data-cy="git-log-item"]' appear 1 times on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 times on screen
 
   Scenario: Commit an added file with commit message succeeds
     #  Check list of logs
     When I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
-    And  I expect '[data-cy="git-log-list"]' exists
-    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
 
-    When I click on '[data-cy="dialog-icon-close"]'
+    When I click on '[data-cy="close-dialog-button"]'
     Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
@@ -100,8 +100,8 @@ Feature: Test modelizer text view: git commit
 
     When I click on '[data-cy="git-menu-commit"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
-    And  I expect '[data-cy="git-commit-staged-item"]' exists
-    And  I expect '[data-cy="git-commit-staged-item-file"]' appear 1 time on screen
+    And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-title"]' exists
+    And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
 
     #  Valid commit message displays a successful notification
     When I set on '[data-cy="git-message-input"]' text "commit"
@@ -113,6 +113,6 @@ Feature: Test modelizer text view: git commit
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
-    And  I expect '[data-cy="git-log-list"]' exists
-    And  I expect '[data-cy="git-log-item"]' appear 2 times on screen
-    And  I expect '[data-cy="git-log-item"]' is "commit"
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 2 times on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' is "commit"

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -8,8 +8,8 @@ Feature: Test modelizer text view: git commit
 
     When I visit the "/"
     And  I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
@@ -38,8 +38,8 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Add file
@@ -57,7 +57,7 @@ Feature: Test modelizer text view: git commit
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
 
     #  Empty commit message displays an error
-    When I click on '[data-cy="git-form-submit"]'
+    When I click on '[data-cy="git-commit-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
     And  I expect '[data-cy="git-commit-form"] [role="alert"]' is "Please type something"
 
@@ -85,8 +85,8 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Add file
@@ -104,8 +104,8 @@ Feature: Test modelizer text view: git commit
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
 
     #  Valid commit message displays a successful notification
-    When I set on '[data-cy="git-message-input"]' text "commit"
-    And  I click on '[data-cy="git-form-submit"]'
+    When I set on '[data-cy="git-commit-form"] [data-cy="message-input"]' text "commit"
+    And  I click on '[data-cy="git-commit-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-commit-dialog"]' not exists
     And  I expect "positive" toast to appear with text "Your files are committed &#129395;!"
 

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -33,18 +33,18 @@ Feature: Test modelizer text view: git commit
     Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
-    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
-    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    When I hover '[data-cy="file-button_projectName"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_projectName"]'
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
+    Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
     #  Add file
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]'
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Commit
@@ -80,18 +80,18 @@ Feature: Test modelizer text view: git commit
     Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
-    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
-    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    When I hover '[data-cy="folder-button_projectName"]' to make it visible
+    And  I click on '[data-cy="folder-button_projectName"]'
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
+    Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
     #  Add file
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]'
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Commit

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -12,7 +12,7 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch"]'
     And  I wait 1 second
     Then I expect '[data-cy="git-menu-commit"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -15,16 +15,16 @@ Feature: Test modelizer text view: git commit
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch-button"]'
     And  I wait 1 second
-    Then I expect '[data-cy="git-menu-commit"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]' exists
 
   Scenario: Commit with no change
-    When I click on '[data-cy="git-menu-commit"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="empty-item"]' exists
 
   Scenario: Commit an added file without commit message fails
     #  Check list of logs
-    When I click on '[data-cy="git-menu-log"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
@@ -35,7 +35,7 @@ Feature: Test modelizer text view: git commit
     #  Create a file
     When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
     And  I click on '[data-cy="file-explorer-buttons-projectName"]'
-    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -45,13 +45,13 @@ Feature: Test modelizer text view: git commit
     #  Add file
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
-    And  I click on '[data-cy="file-explorer-menu-add-file"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Commit
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-commit"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]' exists
 
-    When I click on '[data-cy="git-menu-commit"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-title"]' exists
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
@@ -64,14 +64,14 @@ Feature: Test modelizer text view: git commit
     #  New commit message is not added inside list of logs
     When I click on '[data-cy="close-dialog-button"]'
     And  I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-log"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 times on screen
 
   Scenario: Commit an added file with commit message succeeds
     #  Check list of logs
-    When I click on '[data-cy="git-menu-log"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
@@ -82,7 +82,7 @@ Feature: Test modelizer text view: git commit
     #  Create a file
     When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
     And  I click on '[data-cy="file-explorer-buttons-projectName"]'
-    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -92,13 +92,13 @@ Feature: Test modelizer text view: git commit
     #  Add file
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
-    And  I click on '[data-cy="file-explorer-menu-add-file"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Commit
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-commit"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]' exists
 
-    When I click on '[data-cy="git-menu-commit"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-commit-item"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-title"]' exists
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
@@ -111,7 +111,7 @@ Feature: Test modelizer text view: git commit
 
     #  New commit message is added inside list of logs
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-log"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 2 times on screen

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -7,7 +7,7 @@ Feature: Test modelizer text view: git commit
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on '[data-cy="new-project"]'
+    And  I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -4,13 +4,13 @@ Feature: Test modelizer text view: git commit
 
   Background:
     Given I clear cache
-    And   I set viewport size to "1536" px for width and "960" px for height
+    And   I set viewport size to '1536' px for width and '960' px for height
 
-    When I visit the "/"
+    When I visit the '/'
     And  I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch-button"]'
@@ -27,7 +27,7 @@ Feature: Test modelizer text view: git commit
     When I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' appear 1 time on screen
 
     When I click on '[data-cy="close-dialog-button"]'
     Then I expect '[data-cy="git-log-dialog"]' not exists
@@ -38,7 +38,7 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
@@ -59,7 +59,7 @@ Feature: Test modelizer text view: git commit
     #  Empty commit message displays an error
     When I click on '[data-cy="git-commit-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-commit-dialog"]' exists
-    And  I expect '[data-cy="git-commit-form"] [role="alert"]' is "Please type something"
+    And  I expect '[data-cy="git-commit-form"] [role="alert"]' is 'Please type something'
 
     #  New commit message is not added inside list of logs
     When I click on '[data-cy="close-dialog-button"]'
@@ -67,14 +67,14 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 times on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' appear 1 times on screen
 
   Scenario: Commit an added file with commit message succeeds
     #  Check list of logs
     When I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' appear 1 time on screen
 
     When I click on '[data-cy="close-dialog-button"]'
     Then I expect '[data-cy="git-log-dialog"]' not exists
@@ -85,7 +85,7 @@ Feature: Test modelizer text view: git commit
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
@@ -104,15 +104,15 @@ Feature: Test modelizer text view: git commit
     And  I expect '[data-cy="git-commit-dialog"] [data-cy="staged-item-file"]' appear 1 time on screen
 
     #  Valid commit message displays a successful notification
-    When I set on '[data-cy="git-commit-form"] [data-cy="message-input"]' text "commit"
+    When I set on '[data-cy="git-commit-form"] [data-cy="message-input"]' text 'commit'
     And  I click on '[data-cy="git-commit-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-commit-dialog"]' not exists
-    And  I expect "positive" toast to appear with text "Your files are committed &#129395;!"
+    And  I expect 'positive' toast to appear with text 'Your files are committed &#129395;!'
 
     #  New commit message is added inside list of logs
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 2 times on screen
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' is "commit"
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' appear 2 times on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' is 'commit'

--- a/cypress/e2e/ModelizerPage/TextView/git/commit.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/commit.feature
@@ -7,112 +7,112 @@ Feature: Test modelizer text view: git commit
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    And  I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    And  I click on "[data-cy=\"git-current-branch\"]"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    And  I click on '[data-cy="git-current-branch"]'
     And  I wait 1 second
-    Then I expect "[data-cy=\"git-menu-commit\"]" exists
+    Then I expect '[data-cy="git-menu-commit"]' exists
 
   Scenario: Commit with no change
-    When I click on "[data-cy=\"git-menu-commit\"]"
-    Then I expect "[data-cy=\"git-commit-dialog\"]" exists
-    And  I expect "[data-cy=\"git-commit-empty-item\"]" exists
+    When I click on '[data-cy="git-menu-commit"]'
+    Then I expect '[data-cy="git-commit-dialog"]' exists
+    And  I expect '[data-cy="git-commit-empty-item"]' exists
 
   Scenario: Commit an added file without commit message fails
     #  Check list of logs
-    When I click on "[data-cy=\"git-menu-log\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" exists
-    And  I expect "[data-cy=\"git-log-list\"]" exists
-    And  I expect "[data-cy=\"git-log-item\"]" appear 1 time on screen
+    When I click on '[data-cy="git-menu-log"]'
+    Then I expect '[data-cy="git-log-dialog"]' exists
+    And  I expect '[data-cy="git-log-list"]' exists
+    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
 
-    When I click on "[data-cy=\"dialog-icon-close\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" not exists
+    When I click on '[data-cy="dialog-icon-close"]'
+    Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
-    When I hover "[data-cy=\"file-explorer-buttons-projectName\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer-buttons-projectName\"]"
-    And  I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
+    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-submit\"]"
-    Then I expect "[data-cy=\"file-explorer-newFile.js\"] [data-cy=\"file-label-newFile.js\"]" appear 1 time on screen
+    When I set on '[data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-submit"]'
+    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Add file
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]"
-    And  I click on "[data-cy=\"file-explorer-menu-add-file\"]"
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    And  I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Commit
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-commit\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-commit"]' exists
 
-    When I click on "[data-cy=\"git-menu-commit\"]"
-    Then I expect "[data-cy=\"git-commit-dialog\"]" exists
-    And  I expect "[data-cy=\"git-commit-staged-item\"]" exists
-    And  I expect "[data-cy=\"git-commit-staged-item-file\"]" appear 1 time on screen
+    When I click on '[data-cy="git-menu-commit"]'
+    Then I expect '[data-cy="git-commit-dialog"]' exists
+    And  I expect '[data-cy="git-commit-staged-item"]' exists
+    And  I expect '[data-cy="git-commit-staged-item-file"]' appear 1 time on screen
 
     #  Empty commit message displays an error
-    When I click on "[data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-commit-dialog\"]" exists
-    And  I expect "[data-cy=\"git-commit-form\"] [role=\"alert\"]" is "Please type something"
+    When I click on '[data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-commit-dialog"]' exists
+    And  I expect '[data-cy="git-commit-form"] [role="alert"]' is "Please type something"
 
     #  New commit message is not added inside list of logs
-    When I click on "[data-cy=\"dialog-icon-close\"]"
-    And  I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-log\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" exists
-    And  I expect "[data-cy=\"git-log-list\"]" exists
-    And  I expect "[data-cy=\"git-log-item\"]" appear 1 times on screen
+    When I click on '[data-cy="dialog-icon-close"]'
+    And  I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-log"]'
+    Then I expect '[data-cy="git-log-dialog"]' exists
+    And  I expect '[data-cy="git-log-list"]' exists
+    And  I expect '[data-cy="git-log-item"]' appear 1 times on screen
 
   Scenario: Commit an added file with commit message succeeds
     #  Check list of logs
-    When I click on "[data-cy=\"git-menu-log\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" exists
-    And  I expect "[data-cy=\"git-log-list\"]" exists
-    And  I expect "[data-cy=\"git-log-item\"]" appear 1 time on screen
+    When I click on '[data-cy="git-menu-log"]'
+    Then I expect '[data-cy="git-log-dialog"]' exists
+    And  I expect '[data-cy="git-log-list"]' exists
+    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
 
-    When I click on "[data-cy=\"dialog-icon-close\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" not exists
+    When I click on '[data-cy="dialog-icon-close"]'
+    Then I expect '[data-cy="git-log-dialog"]' not exists
 
     #  Create a file
-    When I hover "[data-cy=\"file-explorer-buttons-projectName\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer-buttons-projectName\"]"
-    And  I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
+    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-submit\"]"
-    Then I expect "[data-cy=\"file-explorer-newFile.js\"] [data-cy=\"file-label-newFile.js\"]" appear 1 time on screen
+    When I set on '[data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-submit"]'
+    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Add file
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]"
-    And  I click on "[data-cy=\"file-explorer-menu-add-file\"]"
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    And  I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Commit
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-commit\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-commit"]' exists
 
-    When I click on "[data-cy=\"git-menu-commit\"]"
-    Then I expect "[data-cy=\"git-commit-dialog\"]" exists
-    And  I expect "[data-cy=\"git-commit-staged-item\"]" exists
-    And  I expect "[data-cy=\"git-commit-staged-item-file\"]" appear 1 time on screen
+    When I click on '[data-cy="git-menu-commit"]'
+    Then I expect '[data-cy="git-commit-dialog"]' exists
+    And  I expect '[data-cy="git-commit-staged-item"]' exists
+    And  I expect '[data-cy="git-commit-staged-item-file"]' appear 1 time on screen
 
     #  Valid commit message displays a successful notification
-    When I set on "[data-cy=\"git-message-input\"]" text "commit"
-    And  I click on "[data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-commit-dialog\"]" not exists
+    When I set on '[data-cy="git-message-input"]' text "commit"
+    And  I click on '[data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-commit-dialog"]' not exists
     And  I expect "positive" toast to appear with text "Your files are committed &#129395;!"
 
     #  New commit message is added inside list of logs
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-log\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" exists
-    And  I expect "[data-cy=\"git-log-list\"]" exists
-    And  I expect "[data-cy=\"git-log-item\"]" appear 2 times on screen
-    And  I expect "[data-cy=\"git-log-item\"]" is "commit"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-log"]'
+    Then I expect '[data-cy="git-log-dialog"]' exists
+    And  I expect '[data-cy="git-log-list"]' exists
+    And  I expect '[data-cy="git-log-item"]' appear 2 times on screen
+    And  I expect '[data-cy="git-log-item"]' is "commit"

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -4,9 +4,9 @@ Feature: Test modelizer text view: common action of git branch menu
     Given I clear cache
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -4,7 +4,7 @@ Feature: Test modelizer text view: common action of git branch menu
     Given I clear cache
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -15,7 +15,7 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I wait 2 seconds
     # Create new branch test 1
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test1"
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
@@ -23,7 +23,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 2
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test2"
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
@@ -31,7 +31,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 3
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test3"
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
@@ -39,7 +39,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 4
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test4"
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
@@ -47,7 +47,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 5
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test5"
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
@@ -57,11 +57,11 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I wait 2 seconds
     And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
-    Then I expect '[data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show 1 more..."
 
-    When I click on '[data-cy="git-branch-expand-local-menu"]'
-    Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show less"
+    When I click on '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"]'
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show less"
 
-    When I click on '[data-cy="project-settings"]'
+    When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show 1 more..."

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -4,61 +4,61 @@ Feature: Test modelizer text view: common action of git branch menu
     Given I clear cache
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Should check the text of expand branches button
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I wait 2 seconds
+    When I click on '[data-cy="git-current-branch"]'
+    And  I wait 2 seconds
     # Create new branch test 1
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" exists
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test1"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I expect '[data-cy="git-newBranch-form"]' exists
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test1"
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    And  I expect '[data-cy="import-project-form"]' is closed
     # Create new branch test 2
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" exists
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test2"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I expect '[data-cy="git-newBranch-form"]' exists
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test2"
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
     # Create new branch test 3
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" exists
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test3"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I expect '[data-cy="git-newBranch-form"]' exists
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test3"
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
     # Create new branch test 4
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" exists
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test4"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I expect '[data-cy="git-newBranch-form"]' exists
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test4"
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
     # Create new branch test 5
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" exists
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test5"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
-    And I expect "[data-cy=\"git-newBranch-form\"]" is closed
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I expect '[data-cy="git-newBranch-form"]' exists
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test5"
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    And  I expect '[data-cy="git-newBranch-form"]' is closed
 
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I wait 2 seconds
-    And I scroll to "bottom" into "[data-cy=\"git-branch-menu\"]"
-    Then I expect "[data-cy=\"git-branch-expand-menu-text\"]" is "Show 1 more..."
+    When I click on '[data-cy="git-current-branch"]'
+    And  I wait 2 seconds
+    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
+    Then I expect '[data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."
 
-    When I click on "[data-cy=\"git-branch-expand-local-menu\"]"
-    Then I expect "[data-cy=\"git-branch-expand-local-menu\"] [data-cy=\"git-branch-expand-menu-text\"]" is "Show less"
+    When I click on '[data-cy="git-branch-expand-local-menu"]'
+    Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show less"
 
-    When I click on "[data-cy=\"project-settings\"]"
-    And I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-branch-expand-local-menu\"] [data-cy=\"git-branch-expand-menu-text\"]" is "Show 1 more..."
+    When I click on '[data-cy="project-settings"]'
+    And  I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -12,7 +12,7 @@ Feature: Test modelizer text view: common action of git branch menu
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Should check the text of expand branches button
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I wait 2 seconds
     # Create new branch test 1
     And  I click on '[data-cy="git-menu-new-branch"]'
@@ -22,7 +22,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 2
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test2"
@@ -30,7 +30,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 3
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test3"
@@ -38,7 +38,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 4
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test4"
@@ -46,7 +46,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 5
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
     And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test5"
@@ -54,7 +54,7 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
 
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I wait 2 seconds
     And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
     Then I expect '[data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."
@@ -63,5 +63,5 @@ Feature: Test modelizer text view: common action of git branch menu
     Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show less"
 
     When I click on '[data-cy="project-settings"]'
-    And  I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-branch-expand-local-menu"] [data-cy="git-branch-expand-menu-text"]' is "Show 1 more..."

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -2,14 +2,14 @@ Feature: Test modelizer text view: common action of git branch menu
 
   Background:
     Given I clear cache
-    And I visit the "/"
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-    When I visit the "/#/modelizer/projectName/text"
+    When I visit the '/#/modelizer/projectName/text'
 
   Scenario: Should check the text of expand branches button
     When I click on '[data-cy="git-current-branch-button"]'
@@ -17,7 +17,7 @@ Feature: Test modelizer text view: common action of git branch menu
     # Create new branch test 1
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test1"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test1'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
@@ -25,7 +25,7 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test2"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test2'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
@@ -33,7 +33,7 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test3"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test3'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
@@ -41,7 +41,7 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test4"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test4'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
@@ -49,19 +49,19 @@ Feature: Test modelizer text view: common action of git branch menu
     When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I expect '[data-cy="git-new-branch-form"]' exists
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test5"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test5'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     And  I expect '[data-cy="git-new-branch-form"]' is closed
 
     When I click on '[data-cy="git-current-branch-button"]'
     And  I wait 2 seconds
-    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
-    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show 1 more..."
+    And  I scroll to 'bottom' into '[data-cy="git-branch-menu"]'
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is 'Show 1 more...'
 
     When I click on '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"]'
-    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show less"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is 'Show less'
 
     When I click on '[data-cy="modelizer-settings-button"]'
     And  I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is "Show 1 more..."
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="expand-local-branch-menu"] [data-cy="expand-list-text"]' is 'Show 1 more...'

--- a/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/common.action.feature
@@ -5,8 +5,8 @@ Feature: Test modelizer text view: common action of git branch menu
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
@@ -16,40 +16,43 @@ Feature: Test modelizer text view: common action of git branch menu
     And  I wait 2 seconds
     # Create new branch test 1
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I expect '[data-cy="git-newBranch-form"]' exists
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test1"
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
-    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I expect '[data-cy="git-new-branch-form"]' exists
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test1"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 2
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I expect '[data-cy="git-newBranch-form"]' exists
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test2"
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    And  I expect '[data-cy="git-new-branch-form"]' exists
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test2"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 3
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I expect '[data-cy="git-newBranch-form"]' exists
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test3"
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    And  I expect '[data-cy="git-new-branch-form"]' exists
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test3"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 4
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I expect '[data-cy="git-newBranch-form"]' exists
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test4"
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    And  I expect '[data-cy="git-new-branch-form"]' exists
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test4"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    And  I expect '[data-cy="git-new-branch-form"]' is closed
     # Create new branch test 5
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I expect '[data-cy="git-newBranch-form"]' exists
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test5"
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
-    And  I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I expect '[data-cy="git-new-branch-form"]' exists
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test5"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    And  I expect '[data-cy="git-new-branch-form"]' is closed
 
     When I click on '[data-cy="git-current-branch"]'
     And  I wait 2 seconds

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -17,7 +17,7 @@ Feature: Test modelizer text view: create git branch
 
   Scenario: Create new branch action with checkout option should create a new branch and checkout on it
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
     And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
 
@@ -32,7 +32,7 @@ Feature: Test modelizer text view: create git branch
 
   Scenario: Create new branch action without checkout option should create a new branch and not checkout on it
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is not checked
 

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -16,7 +16,7 @@ Feature: Test modelizer text view: create git branch
     And  I visit the "/#/modelizer/{{projectName}}/text"
 
   Scenario: Create new branch action with checkout option should create a new branch and checkout on it
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
     And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
@@ -27,11 +27,11 @@ Feature: Test modelizer text view: create git branch
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And  I expect '[data-cy="git-current-branch"]' is "test-new-branch"
+    And  I expect '[data-cy="git-current-branch-button"]' is "test-new-branch"
 
 
   Scenario: Create new branch action without checkout option should create a new branch and not checkout on it
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is not checked
@@ -40,4 +40,4 @@ Feature: Test modelizer text view: create git branch
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And  I expect '[data-cy="git-current-branch"]' is "main"
+    And  I expect '[data-cy="git-current-branch-button"]' is "main"

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: create git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -2,18 +2,18 @@ Feature: Test modelizer text view: create git branch
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I visit the "/#/modelizer/{{projectName}}/text"
+    And  I visit the '/#/modelizer/{{projectName}}/text'
 
   Scenario: Create new branch action with checkout option should create a new branch and checkout on it
     When I click on '[data-cy="git-current-branch-button"]'
@@ -23,11 +23,11 @@ Feature: Test modelizer text view: create git branch
 
     When I wait 2 seconds
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]'
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test-new-branch"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test-new-branch'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-new-branch-form"]' is closed
-    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And  I expect '[data-cy="git-current-branch-button"]' is "test-new-branch"
+    And  I expect 'positive' toast to appear with text 'Branch is created 🥳!'
+    And  I expect '[data-cy="git-current-branch-button"]' is 'test-new-branch'
 
 
   Scenario: Create new branch action without checkout option should create a new branch and not checkout on it
@@ -36,8 +36,8 @@ Feature: Test modelizer text view: create git branch
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is not checked
 
-    When I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test-new-branch"
+    When I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'test-new-branch'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-new-branch-form"]' is closed
-    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And  I expect '[data-cy="git-current-branch-button"]' is "main"
+    And  I expect 'positive' toast to appear with text 'Branch is created 🥳!'
+    And  I expect '[data-cy="git-current-branch-button"]' is 'main'

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -6,38 +6,38 @@ Feature: Test modelizer text view: create git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
-    And I visit the "/#/modelizer/{{projectName}}/text"
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I visit the "/#/modelizer/{{projectName}}/text"
 
   Scenario: Create new branch action with checkout option should create a new branch and checkout on it
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    Then I expect checkbox "[data-cy=\"git-checkout-checkbox\"]" is checked
-    And I expect "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is checked
+    And  I expect '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' exists
 
     When I wait 2 seconds
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]"
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test-new-branch"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-newBranch-form\"]" is closed
-    And I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And I expect "[data-cy=\"git-current-branch\"] " is "test-new-branch"
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]'
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test-new-branch"
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
+    And  I expect '[data-cy="git-current-branch"]' is "test-new-branch"
 
 
   Scenario: Create new branch action without checkout option should create a new branch and not checkout on it
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    And I click on "[data-cy=\"git-checkout-checkbox\"]"
-    Then I expect checkbox "[data-cy=\"git-checkout-checkbox\"]" is not checked
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-checkout-checkbox"]'
+    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is not checked
 
-    When I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "test-new-branch"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-newBranch-form\"]" is closed
-    And I expect "positive" toast to appear with text "Branch is created 🥳!"
-    And I expect "[data-cy=\"git-current-branch\"] " is "main"
+    When I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test-new-branch"
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
+    And  I expect '[data-cy="git-current-branch"]' is "main"

--- a/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/create.branch.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: create git branch
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I visit the "/#/modelizer/{{projectName}}/text"
@@ -18,14 +18,14 @@ Feature: Test modelizer text view: create git branch
   Scenario: Create new branch action with checkout option should create a new branch and checkout on it
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is checked
-    And  I expect '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' exists
+    Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
+    And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
 
     When I wait 2 seconds
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]'
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test-new-branch"
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
-    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]'
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test-new-branch"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
     And  I expect '[data-cy="git-current-branch"]' is "test-new-branch"
 
@@ -33,11 +33,11 @@ Feature: Test modelizer text view: create git branch
   Scenario: Create new branch action without checkout option should create a new branch and not checkout on it
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    And  I click on '[data-cy="git-checkout-checkbox"]'
-    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is not checked
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]'
+    Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is not checked
 
-    When I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "test-new-branch"
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
-    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    When I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "test-new-branch"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
     And  I expect '[data-cy="git-current-branch"]' is "main"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -5,7 +5,7 @@ Feature: Test modelizer text view: git branch display
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -6,8 +6,8 @@ Feature: Test modelizer text view: git branch display
     And I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -13,10 +13,10 @@ Feature: Test modelizer text view: git branch display
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Default branch should be master
-    Then I expect '[data-cy="git-current-branch"]' is "master"
+    Then I expect '[data-cy="git-current-branch-button"]' is "master"
 
   Scenario: Expect to have master in local branches section
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-branch-local-master"]' exists
     And  I expect '[data-cy="git-menu-branch-local-master"] [data-cy="git-menu-current-branch"]' exists
 

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -17,6 +17,6 @@ Feature: Test modelizer text view: git branch display
 
   Scenario: Expect to have master in local branches section
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-branch-local-master"]' exists
-    And  I expect '[data-cy="git-menu-branch-local-master"] [data-cy="git-menu-current-branch"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_master"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_master"] [data-cy="git-menu-current-branch"]' exists
 

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -2,18 +2,18 @@ Feature: Test modelizer text view: git branch display
 
   Background:
     Given I clear cache
-    And I set viewport size to "1536" px for width and "960" px for height
-    And I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-    When I visit the "/#/modelizer/projectName/text"
+    When I visit the '/#/modelizer/projectName/text'
 
   Scenario: Default branch should be master
-    Then I expect '[data-cy="git-current-branch-button"]' is "master"
+    Then I expect '[data-cy="git-current-branch-button"]' is 'master'
 
   Scenario: Expect to have master in local branches section
     When I click on '[data-cy="git-current-branch-button"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -5,9 +5,9 @@ Feature: Test modelizer text view: git branch display
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.branch.feature
@@ -5,18 +5,18 @@ Feature: Test modelizer text view: git branch display
     And I set viewport size to "1536" px for width and "960" px for height
     And I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Default branch should be master
-    Then I expect "[data-cy=\"git-current-branch\"] " is "master"
+    Then I expect '[data-cy="git-current-branch"]' is "master"
 
   Scenario: Expect to have master in local branches section
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-branch-local-master\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-local-master\"] [data-cy=\"git-menu-current-branch\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-branch-local-master"]' exists
+    And  I expect '[data-cy="git-menu-branch-local-master"] [data-cy="git-menu-current-branch"]' exists
 

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -7,7 +7,7 @@ Feature: Test modelizer text view: git log display
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on '[data-cy="new-project"]'
+    And  I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -14,11 +14,11 @@ Feature: Test modelizer text view: git log display
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-log"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="git-log-item"]' exists
 
   Scenario: Display dialog containing the list of logs
     When I wait 1 second
-    And  I click on '[data-cy="git-menu-log"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -12,7 +12,7 @@ Feature: Test modelizer text view: git log display
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch"]'
     Then I expect '[data-cy="git-menu-log"]' exists
 

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -4,13 +4,13 @@ Feature: Test modelizer text view: git log display
 
   Background:
     Given I clear cache
-    And   I set viewport size to "1536" px for width and "960" px for height
+    And   I set viewport size to '1536' px for width and '960' px for height
 
-    When I visit the "/"
+    When I visit the '/'
     And  I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I click on '[data-cy="git-current-branch-button"]'
@@ -21,5 +21,5 @@ Feature: Test modelizer text view: git log display
     And  I click on '[data-cy="git-branch-menu"] [data-cy="git-log-item"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
     And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
-    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' is "Initial commit."
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]' is 'Initial commit.'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -7,19 +7,19 @@ Feature: Test modelizer text view: git log display
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    And  I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    And  I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-log\"]" exists
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    And  I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-log"]' exists
 
   Scenario: Display dialog containing the list of logs
     When I wait 1 second
-    And  I click on "[data-cy=\"git-menu-log\"]"
-    Then I expect "[data-cy=\"git-log-dialog\"]" exists
-    And  I expect "[data-cy=\"git-log-list\"]" exists
-    And  I expect "[data-cy=\"git-log-item\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"git-log-item\"]" is "Initial commit."
+    And  I click on '[data-cy="git-menu-log"]'
+    Then I expect '[data-cy="git-log-dialog"]' exists
+    And  I expect '[data-cy="git-log-list"]' exists
+    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-item"]' is "Initial commit."

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -13,7 +13,7 @@ Feature: Test modelizer text view: git log display
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    And  I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-log"]' exists
 
   Scenario: Display dialog containing the list of logs

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -7,9 +7,9 @@ Feature: Test modelizer text view: git log display
     And   I set viewport size to "1536" px for width and "960" px for height
 
     When I visit the "/"
-    And  I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    And  I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -20,6 +20,6 @@ Feature: Test modelizer text view: git log display
     When I wait 1 second
     And  I click on '[data-cy="git-menu-log"]'
     Then I expect '[data-cy="git-log-dialog"]' exists
-    And  I expect '[data-cy="git-log-list"]' exists
-    And  I expect '[data-cy="git-log-item"]' appear 1 time on screen
-    And  I expect '[data-cy="git-log-item"]' is "Initial commit."
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"]' exists
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' appear 1 time on screen
+    And  I expect '[data-cy="git-log-dialog"] [data-cy="log-list"] [data-cy="item"]]' is "Initial commit."

--- a/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.log.feature
@@ -8,8 +8,8 @@ Feature: Test modelizer text view: git log display
 
     When I visit the "/"
     And  I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -5,9 +5,9 @@ Feature: Test modelizer text view: git status display
     And   I set viewport size to "1536" px for width and "960" px for height
     And   I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -13,7 +13,7 @@ Feature: Test modelizer text view: git status display
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Display dialog containing an empty list
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-status"]' exists
 
     When I click on '[data-cy="git-menu-status"]'
@@ -32,7 +32,7 @@ Feature: Test modelizer text view: git status display
     Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Check file status
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 0 time on screen
@@ -46,7 +46,7 @@ Feature: Test modelizer text view: git status display
     Then I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Check file status
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen
@@ -58,7 +58,7 @@ Feature: Test modelizer text view: git status display
     When I set active file content to "updated content"
 
     #  Check file status
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -5,63 +5,63 @@ Feature: Test modelizer text view: git status display
     And   I set viewport size to "1536" px for width and "960" px for height
     And   I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
 
   Scenario: Display dialog containing an empty list
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-status\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-status"]' exists
 
-    When I click on "[data-cy=\"git-menu-status\"]"
-    Then I expect "[data-cy=\"git-status-dialog\"]" exists
-    And  I expect "[data-cy=\"git-status-empty-item\"]" exists
+    When I click on '[data-cy="git-menu-status"]'
+    Then I expect '[data-cy="git-status-dialog"]' exists
+    And  I expect '[data-cy="git-status-empty-item"]' exists
 
   Scenario: Display file status changes in status dialog
     #  Create a file
-    When I hover "[data-cy=\"file-explorer-buttons-projectName\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer-buttons-projectName\"]"
-    And  I click on "[data-cy=\"file-explorer-menu-create-file\"]"
-    Then I expect "[data-cy=\"create-file-dialog\"]" exists
+    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
+    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on "[data-cy=\"create-file-input\"]" text "newFile.js"
-    And  I click on "[data-cy=\"create-file-submit\"]"
-    Then I expect "[data-cy=\"file-explorer-newFile.js\"] [data-cy=\"file-label-newFile.js\"]" appear 1 time on screen
+    When I set on '[data-cy="create-file-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-submit"]'
+    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Check file status
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-status\"]"
-    Then I expect "[data-cy=\"git-status-dialog\"]" exists
-    And  I expect "[data-cy=\"git-status-staged-item\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"git-status-modified-item\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"git-status-untracked-item\"]" appear 1 time on screen
-    And  I click on "[data-cy=\"dialog-icon-close\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-status"]'
+    Then I expect '[data-cy="git-status-dialog"]' exists
+    And  I expect '[data-cy="git-status-staged-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-modified-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-untracked-item"]' appear 1 time on screen
+    And  I click on '[data-cy="dialog-icon-close"]'
 
     #  Add file
-    When I hover "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]" to make it visible
-    And  I click on "[data-cy=\"file-explorer\"] [data-cy=\"file-explorer-buttons-newFile.js\"]"
-    Then I click on "[data-cy=\"file-explorer-menu-add-file\"]"
+    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    Then I click on '[data-cy="file-explorer-menu-add-file"]'
 
     #  Check file status
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-status\"]"
-    Then I expect "[data-cy=\"git-status-dialog\"]" exists
-    And  I expect "[data-cy=\"git-status-staged-item\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"git-status-modified-item\"]" appear 0 time on screen
-    And  I expect "[data-cy=\"git-status-untracked-item\"]" appear 0 time on screen
-    And  I click on "[data-cy=\"dialog-icon-close\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-status"]'
+    Then I expect '[data-cy="git-status-dialog"]' exists
+    And  I expect '[data-cy="git-status-staged-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-modified-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-untracked-item"]' appear 0 time on screen
+    And  I click on '[data-cy="dialog-icon-close"]'
 
     #  Update file content
     When I set active file content to "updated content"
 
     #  Check file status
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And  I click on "[data-cy=\"git-menu-status\"]"
-    Then I expect "[data-cy=\"git-status-dialog\"]" exists
-    And  I expect "[data-cy=\"git-status-staged-item\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"git-status-modified-item\"]" appear 1 time on screen
-    And  I expect "[data-cy=\"git-status-untracked-item\"]" appear 0 time on screen
-    And  I click on "[data-cy=\"dialog-icon-close\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-status"]'
+    Then I expect '[data-cy="git-status-dialog"]' exists
+    And  I expect '[data-cy="git-status-staged-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-modified-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-untracked-item"]' appear 0 time on screen
+    And  I click on '[data-cy="dialog-icon-close"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -5,7 +5,7 @@ Feature: Test modelizer text view: git status display
     And   I set viewport size to "1536" px for width and "960" px for height
     And   I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -18,7 +18,7 @@ Feature: Test modelizer text view: git status display
 
     When I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
-    And  I expect '[data-cy="git-status-empty-item"]' exists
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="empty-item"]' exists
 
   Scenario: Display file status changes in status dialog
     #  Create a file
@@ -35,10 +35,10 @@ Feature: Test modelizer text view: git status display
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
-    And  I expect '[data-cy="git-status-staged-item"]' appear 0 time on screen
-    And  I expect '[data-cy="git-status-modified-item"]' appear 0 time on screen
-    And  I expect '[data-cy="git-status-untracked-item"]' appear 1 time on screen
-    And  I click on '[data-cy="dialog-icon-close"]'
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="untracked-item"]' appear 1 time on screen
+    And  I click on '[data-cy="close-dialog-button"]'
 
     #  Add file
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
@@ -49,10 +49,10 @@ Feature: Test modelizer text view: git status display
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
-    And  I expect '[data-cy="git-status-staged-item"]' appear 1 time on screen
-    And  I expect '[data-cy="git-status-modified-item"]' appear 0 time on screen
-    And  I expect '[data-cy="git-status-untracked-item"]' appear 0 time on screen
-    And  I click on '[data-cy="dialog-icon-close"]'
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 0 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="untracked-item"]' appear 0 time on screen
+    And  I click on '[data-cy="close-dialog-button"]'
 
     #  Update file content
     When I set active file content to "updated content"
@@ -61,7 +61,7 @@ Feature: Test modelizer text view: git status display
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-status"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
-    And  I expect '[data-cy="git-status-staged-item"]' appear 1 time on screen
-    And  I expect '[data-cy="git-status-modified-item"]' appear 1 time on screen
-    And  I expect '[data-cy="git-status-untracked-item"]' appear 0 time on screen
-    And  I click on '[data-cy="dialog-icon-close"]'
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 1 time on screen
+    And  I expect '[data-cy="git-status-dialog"] [data-cy="untracked-item"]' appear 0 time on screen
+    And  I click on '[data-cy="close-dialog-button"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -6,8 +6,8 @@ Feature: Test modelizer text view: git status display
     And   I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I visit the "/#/modelizer/projectName/text"
@@ -27,8 +27,8 @@ Feature: Test modelizer text view: git status display
     And  I click on '[data-cy="file-explorer-menu-create-file"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-input"]' text "newFile.js"
-    And  I click on '[data-cy="create-file-submit"]'
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
 
     #  Check file status

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -14,9 +14,9 @@ Feature: Test modelizer text view: git status display
 
   Scenario: Display dialog containing an empty list
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-status"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="git-status-item"]' exists
 
-    When I click on '[data-cy="git-menu-status"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="git-status-item"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="empty-item"]' exists
 
@@ -24,7 +24,7 @@ Feature: Test modelizer text view: git status display
     #  Create a file
     When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
     And  I click on '[data-cy="file-explorer-buttons-projectName"]'
-    And  I click on '[data-cy="file-explorer-menu-create-file"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
@@ -33,7 +33,7 @@ Feature: Test modelizer text view: git status display
 
     #  Check file status
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-status"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-status-item"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 0 time on screen
     And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 0 time on screen
@@ -43,11 +43,11 @@ Feature: Test modelizer text view: git status display
     #  Add file
     When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
     And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
-    Then I click on '[data-cy="file-explorer-menu-add-file"]'
+    Then I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Check file status
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-status"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-status-item"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen
     And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 0 time on screen
@@ -59,7 +59,7 @@ Feature: Test modelizer text view: git status display
 
     #  Check file status
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-status"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-status-item"]'
     Then I expect '[data-cy="git-status-dialog"]' exists
     And  I expect '[data-cy="git-status-dialog"] [data-cy="staged-item"]' appear 1 time on screen
     And  I expect '[data-cy="git-status-dialog"] [data-cy="modified-item"]' appear 1 time on screen

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -2,15 +2,15 @@ Feature: Test modelizer text view: git status display
 
   Background:
     Given I clear cache
-    And   I set viewport size to "1536" px for width and "960" px for height
-    And   I visit the "/"
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
-    When I visit the "/#/modelizer/projectName/text"
+    When I visit the '/#/modelizer/projectName/text'
 
   Scenario: Display dialog containing an empty list
     When I click on '[data-cy="git-current-branch-button"]'
@@ -27,7 +27,7 @@ Feature: Test modelizer text view: git status display
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
-    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
+    When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile.js'
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
@@ -55,7 +55,7 @@ Feature: Test modelizer text view: git status display
     And  I click on '[data-cy="close-dialog-button"]'
 
     #  Update file content
-    When I set active file content to "updated content"
+    When I set active file content to 'updated content'
 
     #  Check file status
     When I click on '[data-cy="git-current-branch-button"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/display.status.feature
@@ -22,14 +22,14 @@ Feature: Test modelizer text view: git status display
 
   Scenario: Display file status changes in status dialog
     #  Create a file
-    When I hover '[data-cy="file-explorer-buttons-projectName"]' to make it visible
-    And  I click on '[data-cy="file-explorer-buttons-projectName"]'
+    When I hover '[data-cy="folder-button_projectName"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_projectName"]'
     And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
     Then I expect '[data-cy="create-file-dialog"]' exists
 
     When I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text "newFile.js"
     And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
-    Then I expect '[data-cy="file-explorer-newFile.js"] [data-cy="file-label-newFile.js"]' appear 1 time on screen
+    Then I expect '[data-cy="file-explorer"] [data-cy="file_newFile.js"]' appear 1 time on screen
 
     #  Check file status
     When I click on '[data-cy="git-current-branch-button"]'
@@ -41,8 +41,8 @@ Feature: Test modelizer text view: git status display
     And  I click on '[data-cy="close-dialog-button"]'
 
     #  Add file
-    When I hover '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-explorer-buttons-newFile.js"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_newFile.js"]'
     Then I click on '[data-cy="file-explorer-action-menu"] [data-cy="git-add-file-action-item"]'
 
     #  Check file status

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -2,38 +2,38 @@ Feature: Test modelizer text view: filter git branch
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I visit the "/#/modelizer/{{projectName}}/text"
+    And  I visit the '/#/modelizer/{{projectName}}/text'
 
-  Scenario: Expect to have no branch with "no_main" filter
+  Scenario: Expect to have no branch with 'no_main' filter
     When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'not_main'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
-  Scenario: Expect to have main branch with "main" filter
+  Scenario: Expect to have main branch with 'main' filter
     When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'not_main'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
-    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "main"
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'main'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
@@ -45,31 +45,31 @@ Feature: Test modelizer text view: filter git branch
 
     When I wait 2 seconds
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]'
-    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "testNewBranch"
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text 'testNewBranch'
     And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-new-branch-form"]' is closed
-    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
+    And  I expect 'positive' toast to appear with text 'Branch is created 🥳!'
 
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
-    Then I expect '[data-cy="git-current-branch-button"]' is "testNewBranch"
+    And  I scroll to 'bottom' into '[data-cy="git-branch-menu"]'
+    Then I expect '[data-cy="git-current-branch-button"]' is 'testNewBranch'
     And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I scroll to "top" into '[data-cy="git-branch-menu"]'
-    And  I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    When I scroll to 'top' into '[data-cy="git-branch-menu"]'
+    And  I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'not_main'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_test-testNewBranch"]' not exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
-    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "no_main main"
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'no_main main'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' not exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "no_main main testNewBranch"
-    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text 'no_main main testNewBranch'
+    And  I scroll to 'bottom' into '[data-cy="git-branch-menu"]'
     Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' exists
     And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -16,7 +16,7 @@ Feature: Test modelizer text view: filter git branch
     And  I visit the "/#/modelizer/{{projectName}}/text"
 
   Scenario: Expect to have no branch with "no_main" filter
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-branch-local-main"]' exists
     And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
@@ -25,7 +25,7 @@ Feature: Test modelizer text view: filter git branch
     And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
 
   Scenario: Expect to have main branch with "main" filter
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     Then I expect '[data-cy="git-menu-branch-local-main"]' exists
     And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
@@ -38,7 +38,7 @@ Feature: Test modelizer text view: filter git branch
     And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
   Scenario: Create new branch then check if filter works
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
     And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
@@ -50,9 +50,9 @@ Feature: Test modelizer text view: filter git branch
     Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
 
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
-    Then I expect '[data-cy="git-current-branch"]' is "testNewBranch"
+    Then I expect '[data-cy="git-current-branch-button"]' is "testNewBranch"
     And  I expect '[data-cy="git-menu-branch-local-main"]' exists
     And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' exists
     And  I expect '[data-cy="git-menu-branch-remote-main"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: filter git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: filter git branch
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I visit the "/#/modelizer/{{projectName}}/text"
@@ -40,14 +40,14 @@ Feature: Test modelizer text view: filter git branch
   Scenario: Create new branch then check if filter works
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-new-branch"]'
-    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is checked
-    And  I expect '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' exists
+    Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
+    And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
 
     When I wait 2 seconds
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]'
-    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "testNewBranch"
-    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
-    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]'
+    And  I set on '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' text "testNewBranch"
+    And  I click on '[data-cy="git-new-branch-form"] [data-cy="submit-button"]'
+    Then I expect '[data-cy="git-new-branch-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is created 🥳!"
 
     When I click on '[data-cy="git-current-branch"]'

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -17,29 +17,29 @@ Feature: Test modelizer text view: filter git branch
 
   Scenario: Expect to have no branch with "no_main" filter
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
-    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
   Scenario: Expect to have main branch with "main" filter
     When I click on '[data-cy="git-current-branch-button"]'
-    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
-    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
-    When I set on '[data-cy="git-branch-menu-search-bar"]' text "main"
-    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "main"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
   Scenario: Create new branch then check if filter works
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-new-branch"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="git-new-branch-item"]'
     Then I expect checkbox '[data-cy="git-new-branch-form"] [data-cy="checkout-checkbox"]' is checked
     And  I expect '[data-cy="git-new-branch-form"] [data-cy="branch-name-input"]' exists
 
@@ -53,23 +53,23 @@ Feature: Test modelizer text view: filter git branch
     When I click on '[data-cy="git-current-branch-button"]'
     And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
     Then I expect '[data-cy="git-current-branch-button"]' is "testNewBranch"
-    And  I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
     When I scroll to "top" into '[data-cy="git-branch-menu"]'
-    And  I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
-    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
-    And  I expect '[data-cy="git-menu-branch-local-test-testNewBranch"]' not exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
+    And  I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "not_main"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' not exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_test-testNewBranch"]' not exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' not exists
 
-    When I set on '[data-cy="git-branch-menu-search-bar"]' text "no_main main"
-    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' not exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "no_main main"
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' not exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists
 
-    When I set on '[data-cy="git-branch-menu-search-bar"]' text "no_main main testNewBranch"
+    When I set on '[data-cy="git-branch-menu"] [data-cy="search-branch-input"]' text "no_main main testNewBranch"
     And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
-    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
-    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' exists
-    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
+    Then I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="local-branch_testNewBranch"]' exists
+    And  I expect '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/filter.branch.feature
@@ -6,70 +6,70 @@ Feature: Test modelizer text view: filter git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
-    And I visit the "/#/modelizer/{{projectName}}/text"
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I visit the "/#/modelizer/{{projectName}}/text"
 
   Scenario: Expect to have no branch with "no_main" filter
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
-    When I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "not_main"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" not exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" not exists
+    When I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
+    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
 
   Scenario: Expect to have main branch with "main" filter
-    When I click on "[data-cy=\"git-current-branch\"]"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
-    When I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "not_main"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" not exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" not exists
+    When I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
+    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
 
-    When I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "main"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I set on '[data-cy="git-branch-menu-search-bar"]' text "main"
+    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
   Scenario: Create new branch then check if filter works
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-new-branch\"]"
-    Then I expect checkbox "[data-cy=\"git-checkout-checkbox\"]" is checked
-    And I expect "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-new-branch"]'
+    Then I expect checkbox '[data-cy="git-checkout-checkbox"]' is checked
+    And  I expect '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' exists
 
     When I wait 2 seconds
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]"
-    And I set on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-branch-input\"]" text "testNewBranch"
-    And I click on "[data-cy=\"git-newBranch-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-newBranch-form\"]" is closed
-    And I expect "positive" toast to appear with text "Branch is created 🥳!"
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]'
+    And  I set on '[data-cy="git-newBranch-form"] [data-cy="git-branch-input"]' text "testNewBranch"
+    And  I click on '[data-cy="git-newBranch-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-newBranch-form"]' is closed
+    And  I expect "positive" toast to appear with text "Branch is created 🥳!"
 
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I scroll to "bottom" into "[data-cy=\"git-branch-menu\"]"
-    Then I expect "[data-cy=\"git-current-branch\"] " is "testNewBranch"
-    And I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-local-testNewBranch\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I click on '[data-cy="git-current-branch"]'
+    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
+    Then I expect '[data-cy="git-current-branch"]' is "testNewBranch"
+    And  I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
-    When I scroll to "top" into "[data-cy=\"git-branch-menu\"]"
-    And I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "not_main"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" not exists
-    And I expect "[data-cy=\"git-menu-branch-local-test-testNewBranch\"]" not exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" not exists
+    When I scroll to "top" into '[data-cy="git-branch-menu"]'
+    And  I set on '[data-cy="git-branch-menu-search-bar"]' text "not_main"
+    Then I expect '[data-cy="git-menu-branch-local-main"]' not exists
+    And  I expect '[data-cy="git-menu-branch-local-test-testNewBranch"]' not exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' not exists
 
-    When I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "no_main main"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-local-testNewBranch\"]" not exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I set on '[data-cy="git-branch-menu-search-bar"]' text "no_main main"
+    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' not exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists
 
-    When I set on "[data-cy=\"git-branch-menu-search-bar\"]" text "no_main main testNewBranch"
-    And I scroll to "bottom" into "[data-cy=\"git-branch-menu\"]"
-    Then I expect "[data-cy=\"git-menu-branch-local-main\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-local-testNewBranch\"]" exists
-    And I expect "[data-cy=\"git-menu-branch-remote-main\"]" exists
+    When I set on '[data-cy="git-branch-menu-search-bar"]' text "no_main main testNewBranch"
+    And  I scroll to "bottom" into '[data-cy="git-branch-menu"]'
+    Then I expect '[data-cy="git-menu-branch-local-main"]' exists
+    And  I expect '[data-cy="git-menu-branch-local-testNewBranch"]' exists
+    And  I expect '[data-cy="git-menu-branch-remote-main"]' exists

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -2,18 +2,18 @@ Feature: Test modelizer text view: update git branch
 
   Background:
     Given I clear cache
-    And I set context field "repository_url" with "https://github.com/ditrit/leto-modelizer-project-test"
-    And I set context field "projectName" with "leto-modelizer-project-test"
-    And I visit the "/"
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I visit the '/'
 
     When I click on '[data-cy="import-project-button"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
     And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
-    Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
     And  I expect '[data-cy="import-project-form"]' is closed
-    And  I visit the "/#/modelizer/{{projectName}}/text"
+    And  I visit the '/#/modelizer/{{projectName}}/text'
 
 
   Scenario: Update action should be available only for branch that are local and remote
@@ -38,7 +38,7 @@ Feature: Test modelizer text view: update git branch
 
     When I click on '[data-cy="git-update-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-update-form"]' is closed
-    And I expect "positive" toast to appear with text "Branch is updated 🥳!"
+    And I expect 'positive' toast to appear with text 'Branch is updated 🥳!'
 
   Scenario: Execute update action without fast forward should be a success
     When I click on '[data-cy="git-current-branch-button"]'
@@ -49,4 +49,4 @@ Feature: Test modelizer text view: update git branch
 
     When I click on '[data-cy="git-update-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-update-form"]' is closed
-    And  I expect "positive" toast to appear with text "Branch is updated 🥳!"
+    And  I expect 'positive' toast to appear with text 'Branch is updated 🥳!'

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -6,7 +6,7 @@ Feature: Test modelizer text view: update git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on '[data-cy="import-project"]'
+    When I click on '[data-cy="import-project-button"]'
     And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
     And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
     And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -18,22 +18,22 @@ Feature: Test modelizer text view: update git branch
 
   Scenario: Update action should be available only for branch that are local and remote
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-local-main"]'
-    Then I expect '[data-cy="git-menu-branch-update-main"]' exists
-    And  I click on '[data-cy="git-menu-branch-local-main"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]'
+    Then I expect '[data-cy="git-branch-action-menu"] [data-cy="update_main"]' exists
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]'
 
-    When I click on '[data-cy="git-menu-branch-remote-main"]'
-    Then I expect '[data-cy="git-menu-branch-update-main"]' exists
-    And  I click on '[data-cy="git-menu-branch-remote-main"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]'
+    Then I expect '[data-cy="git-branch-action-menu"] [data-cy="update_main"]' exists
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_main"]'
 
-    When I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
-    Then I expect '[data-cy="git-menu-branch-update-test/remote1"]' not exists
-    And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
+    When I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote1"]'
+    Then I expect '[data-cy="git-branch-action-menu"] [data-cy="update_test/remote1"]' not exists
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="remote-branch_test/remote1"]'
 
   Scenario: Execute update action with fast forward should be a success
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-local-main"]'
-    And  I click on '[data-cy="git-menu-branch-update-main"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="update_main"]'
     Then I expect checkbox '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]' is checked
 
     When I click on '[data-cy="git-update-form"] [data-cy="submit-button"]'
@@ -42,8 +42,8 @@ Feature: Test modelizer text view: update git branch
 
   Scenario: Execute update action without fast forward should be a success
     When I click on '[data-cy="git-current-branch-button"]'
-    And  I click on '[data-cy="git-menu-branch-local-main"]'
-    And  I click on '[data-cy="git-menu-branch-update-main"]'
+    And  I click on '[data-cy="git-branch-menu"] [data-cy="local-branch_main"]'
+    And  I click on '[data-cy="git-branch-action-menu"] [data-cy="update_main"]'
     And  I click on '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]'
     Then I expect checkbox '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]' is not checked
 

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -6,47 +6,47 @@ Feature: Test modelizer text view: update git branch
     And I set context field "projectName" with "leto-modelizer-project-test"
     And I visit the "/"
 
-    When I click on "[data-cy=\"import-project\"]"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-repository-input\"]" text "{{ repository_url }}"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-username-input\"]" text "test"
-    And I set on "[data-cy=\"import-project-form\"] [data-cy=\"git-token-input\"]" text "test"
-    And I click on "[data-cy=\"import-project-form\"] [data-cy=\"import-project-form-submit\"]"
+    When I click on '[data-cy="import-project"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
-    And I expect "[data-cy=\"import-project-form\"]" is closed
-    And I visit the "/#/modelizer/{{projectName}}/text"
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I visit the "/#/modelizer/{{projectName}}/text"
 
 
   Scenario: Update action should be available only for branch that are local and remote
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-branch-local-main\"]"
-    Then I expect "[data-cy=\"git-menu-branch-update-main\"]" exists
-    And I click on "[data-cy=\"git-menu-branch-local-main\"]"
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-local-main"]'
+    Then I expect '[data-cy="git-menu-branch-update-main"]' exists
+    And  I click on '[data-cy="git-menu-branch-local-main"]'
 
-    When I click on "[data-cy=\"git-menu-branch-remote-main\"]"
-    Then I expect "[data-cy=\"git-menu-branch-update-main\"]" exists
-    And I click on "[data-cy=\"git-menu-branch-remote-main\"]"
+    When I click on '[data-cy="git-menu-branch-remote-main"]'
+    Then I expect '[data-cy="git-menu-branch-update-main"]' exists
+    And  I click on '[data-cy="git-menu-branch-remote-main"]'
 
-    When I click on "[data-cy=\"git-menu-branch-remote-test/remote1\"]"
-    Then I expect "[data-cy=\"git-menu-branch-update-test/remote1\"]" not exists
-    And I click on "[data-cy=\"git-menu-branch-remote-test/remote1\"]"
+    When I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
+    Then I expect '[data-cy="git-menu-branch-update-test/remote1"]' not exists
+    And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
 
   Scenario: Execute update action with fast forward should be a success
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-branch-local-main\"]"
-    And I click on "[data-cy=\"git-menu-branch-update-main\"]"
-    Then I expect checkbox "[data-cy=\"git-fastForward-checkbox\"]" is checked
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-local-main"]'
+    And  I click on '[data-cy="git-menu-branch-update-main"]'
+    Then I expect checkbox '[data-cy="git-fastForward-checkbox"]' is checked
 
-    When I click on "[data-cy=\"git-update-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-update-form\"]" is closed
+    When I click on '[data-cy="git-update-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-update-form"]' is closed
     And I expect "positive" toast to appear with text "Branch is updated 🥳!"
 
   Scenario: Execute update action without fast forward should be a success
-    When I click on "[data-cy=\"git-current-branch\"]"
-    And I click on "[data-cy=\"git-menu-branch-local-main\"]"
-    And I click on "[data-cy=\"git-menu-branch-update-main\"]"
-    And I click on "[data-cy=\"git-fastForward-checkbox\"]"
-    Then I expect checkbox "[data-cy=\"git-fastForward-checkbox\"]" is not checked
+    When I click on '[data-cy="git-current-branch"]'
+    And  I click on '[data-cy="git-menu-branch-local-main"]'
+    And  I click on '[data-cy="git-menu-branch-update-main"]'
+    And  I click on '[data-cy="git-fastForward-checkbox"]'
+    Then I expect checkbox '[data-cy="git-fastForward-checkbox"]' is not checked
 
-    When I click on "[data-cy=\"git-update-form\"] [data-cy=\"git-form-submit\"]"
-    Then I expect "[data-cy=\"git-update-form\"]" is closed
-    And I expect "positive" toast to appear with text "Branch is updated 🥳!"
+    When I click on '[data-cy="git-update-form"] [data-cy="git-form-submit"]'
+    Then I expect '[data-cy="git-update-form"]' is closed
+    And  I expect "positive" toast to appear with text "Branch is updated 🥳!"

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -7,10 +7,10 @@ Feature: Test modelizer text view: update git branch
     And I visit the "/"
 
     When I click on '[data-cy="import-project"]'
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-repository-input"]' text "{{ repository_url }}"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-username-input"]' text "test"
-    And  I set on '[data-cy="import-project-form"] [data-cy="git-token-input"]' text "test"
-    And  I click on '[data-cy="import-project-form"] [data-cy="import-project-form-submit"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text "{{ repository_url }}"
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text "test"
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text "test"
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
     Then I expect "positive" toast to appear with text "Project has been imported 🥳!"
     And  I expect '[data-cy="import-project-form"]' is closed
     And  I visit the "/#/modelizer/{{projectName}}/text"
@@ -34,9 +34,9 @@ Feature: Test modelizer text view: update git branch
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-branch-local-main"]'
     And  I click on '[data-cy="git-menu-branch-update-main"]'
-    Then I expect checkbox '[data-cy="git-fastForward-checkbox"]' is checked
+    Then I expect checkbox '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]' is checked
 
-    When I click on '[data-cy="git-update-form"] [data-cy="git-form-submit"]'
+    When I click on '[data-cy="git-update-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-update-form"]' is closed
     And I expect "positive" toast to appear with text "Branch is updated 🥳!"
 
@@ -44,9 +44,9 @@ Feature: Test modelizer text view: update git branch
     When I click on '[data-cy="git-current-branch"]'
     And  I click on '[data-cy="git-menu-branch-local-main"]'
     And  I click on '[data-cy="git-menu-branch-update-main"]'
-    And  I click on '[data-cy="git-fastForward-checkbox"]'
-    Then I expect checkbox '[data-cy="git-fastForward-checkbox"]' is not checked
+    And  I click on '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]'
+    Then I expect checkbox '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]' is not checked
 
-    When I click on '[data-cy="git-update-form"] [data-cy="git-form-submit"]'
+    When I click on '[data-cy="git-update-form"] [data-cy="submit-button"]'
     Then I expect '[data-cy="git-update-form"]' is closed
     And  I expect "positive" toast to appear with text "Branch is updated 🥳!"

--- a/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
+++ b/cypress/e2e/ModelizerPage/TextView/git/update.branch.feature
@@ -17,7 +17,7 @@ Feature: Test modelizer text view: update git branch
 
 
   Scenario: Update action should be available only for branch that are local and remote
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-local-main"]'
     Then I expect '[data-cy="git-menu-branch-update-main"]' exists
     And  I click on '[data-cy="git-menu-branch-local-main"]'
@@ -31,7 +31,7 @@ Feature: Test modelizer text view: update git branch
     And  I click on '[data-cy="git-menu-branch-remote-test/remote1"]'
 
   Scenario: Execute update action with fast forward should be a success
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-local-main"]'
     And  I click on '[data-cy="git-menu-branch-update-main"]'
     Then I expect checkbox '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]' is checked
@@ -41,7 +41,7 @@ Feature: Test modelizer text view: update git branch
     And I expect "positive" toast to appear with text "Branch is updated 🥳!"
 
   Scenario: Execute update action without fast forward should be a success
-    When I click on '[data-cy="git-current-branch"]'
+    When I click on '[data-cy="git-current-branch-button"]'
     And  I click on '[data-cy="git-menu-branch-local-main"]'
     And  I click on '[data-cy="git-menu-branch-update-main"]'
     And  I click on '[data-cy="git-update-form"] [data-cy="fast-forward-checkbox"]'

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -4,25 +4,25 @@ Feature: Test roundtrip of the application
   # TODO: update/fix test
   Scenario: Create project, switch and go back to homepage
     Given I clear cache
-    And  I visit the "/"
+    And   I visit the '/'
 
     When I click on '[data-cy="create-project-button"]'
-    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text 'projectName'
     And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
-    Then I expect current url is "/modelizer/projectName/model"
+    Then I expect current url is '/modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
-    And  I expect current url is "/#/modelizer/projectName/text"
+    And  I expect current url is '/#/modelizer/projectName/text'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
-    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Model'
     And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
-    And  I expect current url is "/#/modelizer/projectName/model"
+    And  I expect current url is '/#/modelizer/projectName/model'
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
-    Then I expect current url is "/"
+    Then I expect current url is '/'
     And  I expect '[data-cy="project-card_projectName"]' exists

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -6,9 +6,9 @@ Feature: Test roundtrip of the application
     Given I clear cache
     And  I visit the "/"
 
-    When I click on '[data-cy="new-project-button"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
+    When I click on '[data-cy="create-project-button"]'
+    And  I set on '[data-cy="create-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="create-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -7,8 +7,8 @@ Feature: Test roundtrip of the application
     And  I visit the "/"
 
     When I click on '[data-cy="new-project"]'
-    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
-    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -4,25 +4,25 @@ Feature: Test roundtrip of the application
   # TODO: update/fix test
   Scenario: Create project, switch and go back to homepage
     Given I clear cache
-    And I visit the "/"
+    And  I visit the "/"
 
-    When I click on "[data-cy=\"new-project\"]"
-    And  I set on "[data-cy=\"new-project-form\"] [data-cy=\"project-name-input\"]" text "projectName"
-    And  I click on "[data-cy=\"new-project-form\"] [data-cy=\"new-project-form-submit\"]"
+    When I click on '[data-cy="new-project"]'
+    And  I set on '[data-cy="new-project-form"] [data-cy="project-name-input"]' text "projectName"
+    And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Text"
-    And  I expect "[data-cy=\"modelizer-text-view\"]" exists
-    And  I expect "[data-cy=\"file-explorer\"]" exists
-    And  I expect "[data-cy=\"file-tabs\"]" exists
-    And I expect current url is "/#/modelizer/projectName/text"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    And  I expect '[data-cy="modelizer-text-view"]' exists
+    And  I expect '[data-cy="file-explorer"]' exists
+    And  I expect '[data-cy="file-tabs"]' exists
+    And  I expect current url is "/#/modelizer/projectName/text"
 
-    When I click on "[data-cy=\"modelizer-switch\"] [aria-pressed=\"false\"]"
-    Then I expect "[data-cy=\"modelizer-switch\"] [aria-pressed=\"true\"] [class=\"block\"]" is "Model"
-    And  I expect "[data-cy=\"modelizer-model-view-draw-root\"]" exists
-    And I expect current url is "/#/modelizer/projectName/model"
+    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
+    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect current url is "/#/modelizer/projectName/model"
 
-    When I click on "[data-cy=\"app-logo-link\"]"
+    When I click on '[data-cy="app-logo-link"]'
     Then I expect current url is "/"
-    And I expect "[data-cy=\"project-card-projectName\"]" exists
+    And  I expect '[data-cy="project-card-projectName"]' exists

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -20,7 +20,7 @@ Feature: Test roundtrip of the application
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
-    And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
+    And  I expect '[data-cy="modelizer-model-view"] [data-cy="draw-container"]' exists
     And  I expect current url is "/#/modelizer/projectName/model"
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -25,4 +25,4 @@ Feature: Test roundtrip of the application
 
     When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
-    And  I expect '[data-cy="project-card-projectName"]' exists
+    And  I expect '[data-cy="project-card_projectName"]' exists

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -6,7 +6,7 @@ Feature: Test roundtrip of the application
     Given I clear cache
     And  I visit the "/"
 
-    When I click on '[data-cy="new-project"]'
+    When I click on '[data-cy="new-project-button"]'
     And  I set on '[data-cy="new-project-form"] [data-cy="name-input"]' text "projectName"
     And  I click on '[data-cy="new-project-form"] [data-cy="submit-button"]'
     Then I expect current url is "/modelizer/projectName/model"

--- a/cypress/e2e/roundtrip.feature
+++ b/cypress/e2e/roundtrip.feature
@@ -11,18 +11,18 @@ Feature: Test roundtrip of the application
     And  I click on '[data-cy="new-project-form"] [data-cy="new-project-form-submit"]'
     Then I expect current url is "/modelizer/projectName/model"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Text"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Text"
     And  I expect '[data-cy="modelizer-text-view"]' exists
     And  I expect '[data-cy="file-explorer"]' exists
     And  I expect '[data-cy="file-tabs"]' exists
     And  I expect current url is "/#/modelizer/projectName/text"
 
-    When I click on '[data-cy="modelizer-switch"] [aria-pressed="false"]'
-    Then I expect '[data-cy="modelizer-switch"] [aria-pressed="true"] [class="block"]' is "Model"
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is "Model"
     And  I expect '[data-cy="modelizer-model-view-draw-root"]' exists
     And  I expect current url is "/#/modelizer/projectName/model"
 
-    When I click on '[data-cy="app-logo-link"]'
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
     Then I expect current url is "/"
     And  I expect '[data-cy="project-card-projectName"]' exists

--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -9,9 +9,9 @@
     no-transition
     no-selection-unset
     class="file-explorer"
-    data-cy="file-explorer"
     :filter="filterTrigger"
     :filter-method="filterParsableFiles"
+    data-cy="file-explorer"
   >
     <template #default-header="{expanded, node}">
       <div

--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -21,7 +21,6 @@
           {'text-grey text-italic' : showParsableFiles && isFolderWithoutParsableFiles(node)},
         ]"
         @dblclick="onNodeDoubleClicked(node)"
-        :data-cy="`file-explorer-${node.label}`"
       >
         <div>
           <q-icon
@@ -29,7 +28,7 @@
             color="primary"
             size="xs"
             :name="`${node.icon}${expanded ? '-open' : ''}`"
-            :data-cy="`file-explorer-icon-${node.label}`"
+            :data-cy="`${node.isFolder ? 'folder': 'file'}-icon_${node.id}`"
           />
           <file-name
             class="tree-node"
@@ -37,15 +36,16 @@
             :isActive="activeFileId  === node.id"
             :label="node.label"
             :status="node.information?.status"
+            :isFolder="node.isFolder"
           />
         </div>
         <span class="col-grow"></span>
         <div class="row no-wrap">
           <file-explorer-action-card
-            class="file-explorer-buttons"
+            class="file-explorer-button"
             :file="node"
             :project-name="projectName"
-            :data-cy="`file-explorer-buttons-${node.label}`"
+            :data-cy="`${node.isFolder ? 'folder': 'file'}-button_${node.id}`"
           />
         </div>
       </div>
@@ -198,12 +198,12 @@ onUnmounted(() => {
     background: rgba($primary, 0.1);
     border-radius: 4px;
 
-    .file-explorer-buttons {
+    .file-explorer-button {
       display: inline-block
     }
   }
 }
-.file-explorer-buttons {
+.file-explorer-button {
   display: none
 }
 </style>

--- a/src/components/FileName.vue
+++ b/src/components/FileName.vue
@@ -1,10 +1,10 @@
 <template>
-    <span
-      :class="[isActive ? 'text-bold' : '', fileStatus]"
-      :data-cy="`file-label-${label}`"
-    >
-      {{ label }}
-    </span>
+  <span
+    :class="[isActive ? 'text-bold' : '', fileStatus]"
+    :data-cy="`${isFolder ? 'folder': 'file'}_${path}`"
+  >
+    {{ label }}
+  </span>
 </template>
 
 <script setup>
@@ -26,6 +26,10 @@ const props = defineProps({
   label: {
     type: String,
     required: true,
+  },
+  isFolder: {
+    type: Boolean,
+    default: false,
   },
 });
 

--- a/src/components/ModelizerModelView.vue
+++ b/src/components/ModelizerModelView.vue
@@ -14,9 +14,9 @@
       <q-page>
         <div
           id="root"
-          data-cy="draw-container"
           @dragover.prevent
           @drop.prevent="dropHandler"
+          data-cy="draw-container"
         >
           <component-drop-overlay />
         </div>

--- a/src/components/ModelizerModelView.vue
+++ b/src/components/ModelizerModelView.vue
@@ -14,7 +14,7 @@
       <q-page>
         <div
           id="root"
-          data-cy="modelizer-model-view-draw-root"
+          data-cy="draw-container"
           @dragover.prevent
           @drop.prevent="dropHandler"
         >

--- a/src/components/ModelizerModelsView.vue
+++ b/src/components/ModelizerModelsView.vue
@@ -39,15 +39,15 @@
           />
         </router-link>
       </div>
-      <TemplateGrid
+      <template-grid
         class="col-md-8"
         :templates="templates"
-        @add:template="openNewModelTemplateDialog"
+        @add:template="openImportModelTemplateDialog"
       >
         <template v-slot:header>
           <h4>{{ $t('page.models.template.create') }}</h4>
         </template>
-      </TemplateGrid>
+      </template-grid>
     </div>
   </div>
 </template>
@@ -98,10 +98,10 @@ async function updateModels() {
 }
 
 /**
- * Open NewProjectTemplate dialog.
+ * Open ImportModelTemplate dialog.
  * @param {Object} template - Selected project template.
  */
-async function openNewModelTemplateDialog(template) {
+async function openImportModelTemplateDialog(template) {
   DialogEvent.next({
     type: 'open',
     key: 'ImportModelTemplate',

--- a/src/components/ModelizerNavigationBar.vue
+++ b/src/components/ModelizerNavigationBar.vue
@@ -1,11 +1,12 @@
 <template>
   <q-header
     class="bg-primary text-white shadow-1 row justify-between items-center q-px-lg"
+    data-cy="navigation-bar"
   >
-    <div class="app-homepage-link">
+    <div>
       <router-link
-        class="app-logo-link"
-        data-cy="app-logo-link"
+        class="home-page-link"
+        data-cy="home-page-link"
         to="/"
       >
         <q-icon
@@ -14,7 +15,7 @@
           name="img:icons/logo_modelizer.svg"
           :left="true"
         />
-        <label class="app-logo-label vertical-middle">
+        <label class="icon-label vertical-middle">
           {{ $t('application.name') }}
         </label>
       </router-link>
@@ -53,7 +54,7 @@
         text-color="accent"
         color="white"
         no-caps
-        data-cy="modelizer-switch"
+        data-cy="modelizer-switch-button"
         rounded
       />
       <modelizer-settings-menu :project-name="projectName" />
@@ -181,10 +182,10 @@ onUnmounted(() => {
 .q-header {
   position: relative;
 }
-.app-logo-link {
+.home-page-link {
   text-decoration: none;
 
-  .app-logo-label{
+  .icon-label{
     cursor: pointer;
     color: white;
     font-size: medium;

--- a/src/components/ModelizerNavigationBar.vue
+++ b/src/components/ModelizerNavigationBar.vue
@@ -6,8 +6,8 @@
     <div>
       <router-link
         class="home-page-link"
-        data-cy="home-page-link"
         to="/"
+        data-cy="home-page-link"
       >
         <q-icon
           color="primary"
@@ -54,8 +54,8 @@
         text-color="accent"
         color="white"
         no-caps
-        data-cy="modelizer-switch-button"
         rounded
+        data-cy="modelizer-switch-button"
       />
       <modelizer-settings-menu :project-name="projectName" />
     </div>

--- a/src/components/card/ComponentDefinitionCard.vue
+++ b/src/components/card/ComponentDefinitionCard.vue
@@ -28,12 +28,12 @@
         <q-icon
           v-if="definition.url"
           class="absolute-top-right q-ma-xs"
-          data-cy="url-icon"
           name="fa-solid fa-circle-info"
           color="info"
           size="xs"
           @click.stop="$event.preventDefault()"
           style="cursor: help"
+          data-cy="url-icon"
         >
           <definition-menu :definition="definition"/>
         </q-icon>

--- a/src/components/card/ComponentDefinitionCard.vue
+++ b/src/components/card/ComponentDefinitionCard.vue
@@ -8,7 +8,7 @@
     @dragend="dragEndHandler"
     :id="`component-definition-${definition.type}`"
     :title="definition.description"
-    :data-cy="`component-definition-${definition.type}`"
+    :data-cy="`component-definition_${definition.type}`"
   >
     <q-item
       clickable
@@ -28,7 +28,7 @@
         <q-icon
           v-if="definition.url"
           class="absolute-top-right q-ma-xs"
-          data-cy="component-definition-url"
+          data-cy="url-icon"
           name="fa-solid fa-circle-info"
           color="info"
           size="xs"

--- a/src/components/card/GitBranchCard.vue
+++ b/src/components/card/GitBranchCard.vue
@@ -8,7 +8,7 @@
     icon="fa-solid fa-code-branch"
     :loading="loading"
     :label="currentBranch"
-    data-cy="git-current-branch"
+    data-cy="git-current-branch-button"
   >
     <template v-slot:loading>
       <q-spinner-dots/>
@@ -18,6 +18,7 @@
 </template>
 
 <script setup>
+// TODO : Rename file
 import { getCurrentBranch } from 'src/composables/Project';
 import { useRoute } from 'vue-router';
 import { onMounted, onUnmounted, ref } from 'vue';

--- a/src/components/card/ModelCard.vue
+++ b/src/components/card/ModelCard.vue
@@ -22,12 +22,12 @@
           round
           color="negative"
           icon="fa-solid fa-trash"
-          data-cy="delete-button"
           @click.prevent.stop="DialogEvent.next({
             type: 'open',
             key: 'DeleteModel',
             model,
           })"
+          data-cy="delete-button"
         />
         <q-btn
           class="q-mr-none"
@@ -36,12 +36,12 @@
           round
           color="primary"
           icon="fa-solid fa-pen"
-          data-cy="rename-button"
           @click.prevent.stop="DialogEvent.next({
             type: 'open',
             key: 'RenameModel',
             model,
           })"
+          data-cy="rename-button"
         />
       </div>
     </q-img>

--- a/src/components/card/ModelCard.vue
+++ b/src/components/card/ModelCard.vue
@@ -2,12 +2,12 @@
   <q-card
     class="model-card cursor-pointer"
     v-ripple
-    :data-cy="`model-card$-${model.plugin}-${model.name}`"
+    :data-cy="`model-card_${model.plugin}-${model.name}`"
   >
     <q-img :src="getModelImage()" height="100%">
       <div
         class="absolute-bottom text-subtitle2 text-center"
-        data-cy="model-card-title"
+        data-cy="title-container"
       >
         <div class="text-bold">
           {{ model.name }}
@@ -22,7 +22,7 @@
           round
           color="negative"
           icon="fa-solid fa-trash"
-          data-cy="model-delete-button"
+          data-cy="delete-button"
           @click.prevent.stop="DialogEvent.next({
             type: 'open',
             key: 'DeleteModel',
@@ -36,7 +36,7 @@
           round
           color="primary"
           icon="fa-solid fa-pen"
-          data-cy="model-rename-button"
+          data-cy="rename-button"
           @click.prevent.stop="DialogEvent.next({
             type: 'open',
             key: 'RenameModel',

--- a/src/components/card/ProjectCard.vue
+++ b/src/components/card/ProjectCard.vue
@@ -24,12 +24,12 @@
             round
             color="negative"
             icon="fa-solid fa-trash"
-            data-cy="delete-button"
             @click.stop.prevent="DialogEvent.next({
               type: 'open',
               key: 'DeleteProject',
               id: project.id,
             })"
+            data-cy="delete-button"
           />
           <q-btn
             class="q-mr-none"
@@ -38,12 +38,12 @@
             round
             color="primary"
             icon="fa-solid fa-pen"
-            data-cy="rename-button"
             @click.stop.prevent="DialogEvent.next({
               type: 'open',
               key: 'RenameProject',
               id: project.id,
             })"
+            data-cy="rename-button"
           />
         </div>
       </q-img>

--- a/src/components/card/ProjectCard.vue
+++ b/src/components/card/ProjectCard.vue
@@ -1,19 +1,18 @@
 <template>
   <router-link
     class="card-link"
-    :data-cy="`project-card-${project.id}`"
     :to="`/modelizer/${project.id}/models`"
   >
     <q-card
       v-ripple
       tabindex="0"
       class="cursor-pointer project-card"
-      data-cy="project-card"
+      :data-cy="`project-card_${project.id}`"
     >
       <q-img :src="getProjectImage()" height="100%">
         <div
           class="absolute-bottom text-subtitle2 text-center"
-          data-cy="project-card-title"
+          data-cy="title-container"
         >
           <div>
             {{ project.id }}
@@ -25,7 +24,7 @@
             round
             color="negative"
             icon="fa-solid fa-trash"
-            :data-cy="`delete-project-${project.id}`"
+            data-cy="delete-button"
             @click.stop.prevent="DialogEvent.next({
               type: 'open',
               key: 'DeleteProject',
@@ -39,7 +38,7 @@
             round
             color="primary"
             icon="fa-solid fa-pen"
-            :data-cy="`rename-project-${project.id}`"
+            data-cy="rename-button"
             @click.stop.prevent="DialogEvent.next({
               type: 'open',
               key: 'RenameProject',

--- a/src/components/card/TemplateCard.vue
+++ b/src/components/card/TemplateCard.vue
@@ -3,6 +3,7 @@
     v-ripple
     tabindex="0"
     class="cursor-pointer template-card"
+    :data-cy="`template-card_${template.key}`"
   >
     <q-img
       :src="`/template-library/templates/${template.key}/icon.svg`"
@@ -10,7 +11,7 @@
     >
       <div
         class="absolute-bottom text-subtitle2 text-center"
-        data-cy="template-card-title"
+        data-cy="title-container"
       >
         {{ template.type }}
       </div>

--- a/src/components/dialog/CreateFileDialog.vue
+++ b/src/components/dialog/CreateFileDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="CreateFile" data-cy="create-file-dialog">
+  <default-dialog
+    dialog-key="CreateFile"
+    data-cy="create-file-dialog"
+  >
     <template v-slot:title>
       <q-icon
         color="primary"

--- a/src/components/dialog/CreateProjectDialog.vue
+++ b/src/components/dialog/CreateProjectDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <default-dialog
-    dialog-key="NewProject"
-    data-cy="new-project-dialog"
+    dialog-key="CreateProject"
+    data-cy="create-project-dialog"
   >
     <template v-slot:title>
       <q-icon
@@ -11,7 +11,7 @@
       {{ $t(`page.home.project.create`) }}
     </template>
     <template v-slot:default>
-      <new-project-form
+      <create-project-form
         @project:create="createProject"
       />
     </template>
@@ -21,7 +21,7 @@
 <script setup>
 import DialogEvent from 'src/composables/events/DialogEvent';
 import DefaultDialog from 'src/components/dialog/DefaultDialog';
-import NewProjectForm from 'src/components/form/NewProjectForm';
+import CreateProjectForm from 'src/components/form/CreateProjectForm';
 import { useRouter } from 'vue-router';
 import { initProject } from 'src/composables/Project';
 import { Notify } from 'quasar';
@@ -32,14 +32,14 @@ const { t } = useI18n();
 
 /**
  * Create project on fs, init project on git,
- * close NewProject and redirect to project page.
+ * close CreateProject and redirect to project page.
  * Manage notification.
  */
 async function createProject(projectId) {
   const project = { id: projectId };
 
   await initProject(project).then(() => {
-    DialogEvent.next({ type: 'close', key: 'NewProject' });
+    DialogEvent.next({ type: 'close', key: 'CreateProject' });
     router.push(`/modelizer/${projectId}/models`);
     Notify.create({
       type: 'positive',

--- a/src/components/dialog/CreateProjectTemplateDialog.vue
+++ b/src/components/dialog/CreateProjectTemplateDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <default-dialog
-    dialog-key="NewProjectTemplate"
-    data-cy="new-project-template-dialog"
+    dialog-key="CreateProjectTemplate"
+    data-cy="create-project-template-dialog"
   >
     <template v-slot:title>
       <q-icon
@@ -46,7 +46,7 @@
       <div class="text-subtitle2 q-pb-md">
         {{ $t('page.home.template.selected', { template: templateName }) }}
       </div>
-      <new-project-template-form
+      <create-project-template-form
         @project:add="addProject"
         @update:checked="e => isChecked = e"
         :template="projectTemplate"
@@ -59,7 +59,7 @@
 <script setup>
 import DialogEvent from 'src/composables/events/DialogEvent';
 import DefaultDialog from 'src/components/dialog/DefaultDialog';
-import NewProjectTemplateForm from 'src/components/form/NewProjectTemplateForm';
+import CreateProjectTemplateForm from 'src/components/form/CreateProjectTemplateForm';
 import { useRouter } from 'vue-router';
 import {
   onMounted,
@@ -76,11 +76,11 @@ const templateName = computed(() => projectTemplate.value.type);
 let dialogEventSubscription;
 
 /**
- * Close NewProjectTemplate and redirect to project model page.
+ * Close CreateProjectTemplate and redirect to project model page.
  * @param {String} projectId - Id of the new project.
  */
 function addProject(projectId) {
-  DialogEvent.next({ type: 'close', key: 'NewProjectTemplate' });
+  DialogEvent.next({ type: 'close', key: 'CreateProjectTemplate' });
   router.push(`/modelizer/${projectId}/models`);
 }
 
@@ -90,7 +90,7 @@ function addProject(projectId) {
  * @param {Object} template - Selected template.
  */
 function setProjectTemplate({ key, template }) {
-  if (key === 'NewProjectTemplate') {
+  if (key === 'CreateProjectTemplate') {
     projectTemplate.value = template;
   }
 }

--- a/src/components/dialog/DefaultDialog.vue
+++ b/src/components/dialog/DefaultDialog.vue
@@ -3,9 +3,9 @@
     <q-card class="q-pa-md">
       <q-btn
         icon="fa-solid fa-xmark"
-        class="dialog-icon-close"
+        class="close-dialog-button"
         flat round dense v-close-popup
-        data-cy="dialog-icon-close"
+        data-cy="close-dialog-button"
       />
       <q-card-section class="text-h6 q-mb-xl">
         <slot name="title"></slot>
@@ -24,7 +24,10 @@ import {
 import DialogEvent from 'src/composables/events/DialogEvent';
 
 const props = defineProps({
-  dialogKey: String,
+  dialogKey: {
+    type: String,
+    required: true,
+  },
 });
 const show = ref(false);
 let dialogEventSubscription;
@@ -48,7 +51,7 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-  .dialog-icon-close {
+  .close-dialog-button {
     position: absolute;
     top: 2px;
     right: 2px;

--- a/src/components/dialog/DeleteFileDialog.vue
+++ b/src/components/dialog/DeleteFileDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="DeleteFile" data-cy="delete-file-dialog">
+  <default-dialog
+    dialog-key="DeleteFile"
+    data-cy="delete-file-dialog"
+  >
     <template v-slot:title>
       <q-icon
         color="primary"

--- a/src/components/dialog/GitCommitDialog.vue
+++ b/src/components/dialog/GitCommitDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="GitCommit" data-cy="git-commit-dialog">
+  <default-dialog
+    dialog-key="GitCommit"
+    data-cy="git-commit-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.modelizer.git.commit.title') }}
@@ -14,7 +17,7 @@
         <q-list style="min-width: 500px" dense>
           <q-item
             v-if="stagedFiles.length === 0"
-            data-cy="git-commit-empty-item"
+            data-cy="empty-item"
           >
             <q-item-section>
               {{ $t('page.modelizer.git.status.nothing') }}
@@ -23,16 +26,16 @@
           <template v-else>
             <q-item
               class="text-weight-bold text-grey-7"
-              data-cy="git-commit-staged-item"
+              data-cy="staged-item-title"
             >
               <q-item-section>
                 {{ $t('page.modelizer.git.status.staged') }}
               </q-item-section>
             </q-item>
             <q-item
-              :key="`staged_${file.path}`"
               v-for="file in stagedFiles"
-              data-cy="git-commit-staged-item-file"
+              :key="`staged_${file.path}`"
+              data-cy="staged-item-file"
             >
               <q-item-section class="file-status-staged q-pl-md">
                 {{file.path}}

--- a/src/components/dialog/GitLogDialog.vue
+++ b/src/components/dialog/GitLogDialog.vue
@@ -14,13 +14,13 @@
           :offset="250"
           :scroll-target="scrollTargetRef"
         >
-          <q-list data-cy="git-log-list">
+          <q-list data-cy="log-list">
             <template v-for="(item) in logItems" :key="item.oid">
               <q-expansion-item
                 header-class="bg-primary text-white"
                 expand-icon-class="text-white"
                 expand-separator
-                data-cy="git-log-item"
+                data-cy="item"
               >
                 <template v-slot:header>
                   <q-item-section class="text-bold" color="primary" avatar>

--- a/src/components/dialog/GitNewBranchDialog.vue
+++ b/src/components/dialog/GitNewBranchDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="GitNewBranch" data-cy="git-newBranch-dialog">
+  <default-dialog
+    dialog-key="GitNewBranch"
+    data-cy="git-new-branch-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.modelizer.git.newBranch.title') }}

--- a/src/components/dialog/GitPushDialog.vue
+++ b/src/components/dialog/GitPushDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="GitPush" data-cy="git-push-dialog">
+  <default-dialog
+    dialog-key="GitPush"
+    data-cy="git-push-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.modelizer.git.push.title') }}

--- a/src/components/dialog/GitStatusDialog.vue
+++ b/src/components/dialog/GitStatusDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="GitStatus" data-cy="git-status-dialog">
+  <default-dialog
+    dialog-key="GitStatus"
+    data-cy="git-status-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.modelizer.git.status.title') }}
@@ -16,7 +19,7 @@
         <q-list style="min-width: 500px" dense>
           <q-item
             v-if="noFiles"
-            data-cy="git-status-empty-item"
+            data-cy="empty-item"
           >
             <q-item-section>
               {{ $t('page.modelizer.git.status.nothing') }}
@@ -35,7 +38,7 @@
             >
               <q-item-section
                 class="file-status-staged q-pl-md"
-                data-cy="git-status-staged-item"
+                data-cy="staged-item"
               >
                 {{file.path}}
               </q-item-section>
@@ -54,7 +57,7 @@
             >
               <q-item-section
                 class="file-status-modified q-pl-md"
-                data-cy="git-status-modified-item"
+                data-cy="modified-item"
               >
                 {{file.path}}
               </q-item-section>
@@ -68,12 +71,12 @@
               </q-item-section>
             </q-item>
             <q-item
-              :key="`untracked_${file.path}`"
               v-for="file in untrackedFiles"
+              :key="`untracked_${file.path}`"
             >
               <q-item-section
                 class="file-status-untracked q-pl-md"
-                data-cy="git-status-untracked-item"
+                data-cy="untracked-item"
               >
                 {{file.path}}
               </q-item-section>

--- a/src/components/dialog/GitUpdateDialog.vue
+++ b/src/components/dialog/GitUpdateDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="GitUpdate" data-cy="git-update-dialog">
+  <default-dialog
+    dialog-key="GitUpdate"
+    data-cy="git-update-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.modelizer.git.update.title') }}

--- a/src/components/dialog/ImportProjectDialog.vue
+++ b/src/components/dialog/ImportProjectDialog.vue
@@ -1,5 +1,8 @@
 <template>
-  <default-dialog dialog-key="ImportProject" data-cy="import-project-dialog">
+  <default-dialog
+    dialog-key="ImportProject"
+    data-cy="import-project-dialog"
+  >
     <template v-slot:title>
       <q-icon color="primary" name="fa-brands fa-git-alt" />
       {{ $t('page.home.project.import') }}

--- a/src/components/drawer/ComponentDefinitionsDrawer.vue
+++ b/src/components/drawer/ComponentDefinitionsDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <default-drawer
-    data-cy="components-definitions-drawer"
     class="components-definitions-drawer"
+    data-cy="components-definitions-drawer"
   >
     <template v-slot:drawerName>
       {{ $t('page.modelizer.drawer.components.header') }}
@@ -20,8 +20,8 @@
       <q-input
         clearable
         v-model="definitionFilter"
-        data-cy="definitions-filter-input"
         :label="$t('page.modelizer.drawer.components.filterLabel')"
+        data-cy="definitions-filter-input"
       >
         <template v-slot:prepend>
           <q-icon name="fa-solid fa-magnifying-glass" />

--- a/src/components/drawer/ComponentDefinitionsDrawer.vue
+++ b/src/components/drawer/ComponentDefinitionsDrawer.vue
@@ -20,7 +20,7 @@
       <q-input
         clearable
         v-model="definitionFilter"
-        data-cy="filter-plugin-definitions"
+        data-cy="definitions-filter-input"
         :label="$t('page.modelizer.drawer.components.filterLabel')"
       >
         <template v-slot:prepend>
@@ -35,10 +35,10 @@
           header-class="text-bold"
           class="plugin-definitions"
           :key="plugin.data.name"
-          :data-cy="`plugin-definitions-${plugin.data.name}`"
+          :data-cy="`component-defnitions-item_${plugin.data.name}`"
         >
           <template v-slot:header>
-            <q-item-section data-cy="plugin-definitions-title">
+            <q-item-section data-cy="title">
               {{ plugin.data.name }}
             </q-item-section>
           </template>
@@ -58,10 +58,10 @@
           group="components-definitions"
           header-class="text-bold"
           class="template-definitions"
-          data-cy="`template-definitions"
+          data-cy="template-definitions-item"
         >
           <template v-slot:header>
-            <q-item-section data-cy="template-definitions-title">
+            <q-item-section data-cy="title">
               {{  $t('page.modelizer.drawer.templates.title') }}
             </q-item-section>
           </template>

--- a/src/components/drawer/ComponentDetailPanel.vue
+++ b/src/components/drawer/ComponentDetailPanel.vue
@@ -19,7 +19,7 @@
             round
             flat
             icon="fa-solid fa-xmark"
-            data-cy="object-details-panel-close-button"
+            data-cy="close-button"
             @click="isVisible = false"
           />
         </q-item-section>
@@ -70,7 +70,7 @@
                 color="positive"
                 :loading="submitting"
                 @click="save"
-                data-cy="object-details-panel-save-button"
+                data-cy="save-button"
               >
                 <template v-slot:loading>
                   <q-spinner-dots/>
@@ -80,7 +80,7 @@
                 icon="fa-solid fa-arrow-rotate-left"
                 :label="$t('plugin.component.attribute.reset')"
                 color="info"
-                data-cy="object-details-panel-reset-button"
+                data-cy="reset-button"
                 @click="reset"
               />
             </q-item>

--- a/src/components/drawer/ComponentDetailPanel.vue
+++ b/src/components/drawer/ComponentDetailPanel.vue
@@ -3,9 +3,9 @@
     v-model="isVisible"
     no-swipe-close
     bordered
-    data-cy="object-details-panel"
     side="right"
     :width="350"
+    data-cy="object-details-panel"
   >
     <q-list>
       <q-item>
@@ -19,8 +19,8 @@
             round
             flat
             icon="fa-solid fa-xmark"
-            data-cy="close-button"
             @click="isVisible = false"
+            data-cy="close-button"
           />
         </q-item-section>
       </q-item>
@@ -80,8 +80,8 @@
                 icon="fa-solid fa-arrow-rotate-left"
                 :label="$t('plugin.component.attribute.reset')"
                 color="info"
-                data-cy="reset-button"
                 @click="reset"
+                data-cy="reset-button"
               />
             </q-item>
           </template>

--- a/src/components/form/CreateFileForm.vue
+++ b/src/components/form/CreateFileForm.vue
@@ -9,7 +9,7 @@
       filled
       :label="$t(`page.modelizer.fileExplorer.create.${isFolder ? 'folder' : 'file'}.input`)"
       lazy-rules
-      data-cy="create-file-input"
+      data-cy="name-input"
       :rules="[
         (v) => notEmpty(t, v),
         (v) => isValidFileLabel($t, v),
@@ -22,7 +22,7 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="create-file-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/CreateFileForm.vue
+++ b/src/components/form/CreateFileForm.vue
@@ -1,20 +1,20 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="create-file-form"
     class="q-gutter-md create-file-form"
+    data-cy="create-file-form"
   >
     <q-input
       v-model="fileName"
       filled
       :label="$t(`page.modelizer.fileExplorer.create.${isFolder ? 'folder' : 'file'}.input`)"
       lazy-rules
-      data-cy="name-input"
       :rules="[
         (v) => notEmpty(t, v),
         (v) => isValidFileLabel($t, v),
         (v) => isUniqueFileLabel($t, file.children, v),
       ]"
+      data-cy="name-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -22,8 +22,8 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/CreateModelForm.vue
+++ b/src/components/form/CreateModelForm.vue
@@ -9,7 +9,7 @@
       filled
       :label="$t('actions.models.create.form.name')"
       lazy-rules
-      data-cy="create-model-name-input"
+      data-cy="name-input"
       :rules="[
         (v) => notEmpty($t, v),
       ]"
@@ -29,7 +29,7 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="create-model-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/CreateModelForm.vue
+++ b/src/components/form/CreateModelForm.vue
@@ -1,18 +1,18 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="create-model-form"
     class="q-gutter-md create-model-form"
+    data-cy="create-model-form"
   >
     <q-input
       v-model="modelName"
       filled
       :label="$t('actions.models.create.form.name')"
       lazy-rules
-      data-cy="name-input"
       :rules="[
         (v) => notEmpty($t, v),
       ]"
+      data-cy="name-input"
     />
     <q-select
       filled
@@ -29,8 +29,8 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/CreateProjectForm.vue
+++ b/src/components/form/CreateProjectForm.vue
@@ -20,9 +20,9 @@
         :label="$t(`actions.home.createProject`)"
         icon="fa-solid fa-save"
         type="submit"
+        color="positive"
         data-cy="submit-button"
-        color="positive">
-      </q-btn>
+      />
     </div>
   </q-form>
 </template>

--- a/src/components/form/CreateProjectForm.vue
+++ b/src/components/form/CreateProjectForm.vue
@@ -1,15 +1,15 @@
 <template>
   <q-form
     @submit="onSubmit"
-    class="q-gutter-md new-project-form"
-    data-cy="new-project-form"
+    class="q-gutter-md create-project-form"
+    data-cy="create-project-form"
   >
     <q-input
       v-model="projectName"
       :label="$t('page.home.project.name')"
       :rules="[
         v => notEmpty($t, v),
-        v => isUniqueProjectName($t, Object.keys(getProjects()), v)
+        v => isUniqueProjectName($t, projectNames, v)
       ]"
       filled
       lazy-rules
@@ -40,9 +40,10 @@ import {
 const emit = defineEmits(['project:create']);
 
 const projectName = ref('');
+const projectNames = ref(Object.keys(getProjects()));
 
 /**
- * Emit new project name.
+ * Emit created project name.
  */
 function onSubmit() {
   emit('project:create', projectName.value);
@@ -50,7 +51,7 @@ function onSubmit() {
 </script>
 
 <style lang="scss" scoped>
-.new-project-form {
+.create-project-form {
   min-width: 400px;
 }
 </style>

--- a/src/components/form/CreateProjectTemplateForm.vue
+++ b/src/components/form/CreateProjectTemplateForm.vue
@@ -54,8 +54,9 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
+        color="positive"
         data-cy="submit-button"
-        color="positive">
+      >
         <template v-slot:loading>
           <q-spinner-dots/>
         </template>

--- a/src/components/form/CreateProjectTemplateForm.vue
+++ b/src/components/form/CreateProjectTemplateForm.vue
@@ -1,15 +1,15 @@
 <template>
   <q-form
     @submit="onSubmit"
-    class="q-gutter-md new-project-template-form"
-    data-cy="new-project-template-form"
+    class="q-gutter-md create-project-template-form"
+    data-cy="create-project-template-form"
   >
     <q-input
       v-model="projectName"
       :label="$t('page.home.project.name')"
       :rules="[
         v => notEmpty($t, v),
-        v => isUniqueProjectName($t, Object.keys(getProjects()), v)
+        v => isUniqueProjectName($t, projectNames, v)
       ]"
       filled
       lazy-rules
@@ -98,6 +98,7 @@ const props = defineProps({
 const { t } = useI18n();
 const project = {};
 const projectName = ref('');
+const projectNames = ref(Object.keys(getProjects()));
 const localIsChecked = ref(props.isChecked);
 const repository = ref();
 const username = ref();
@@ -170,7 +171,7 @@ watch(() => props.isChecked, () => {
 </script>
 
 <style lang="scss" scoped>
-.new-project-template-form {
+.create-project-template-form {
   min-width: 400px;
 }
 </style>

--- a/src/components/form/DeleteFileForm.vue
+++ b/src/components/form/DeleteFileForm.vue
@@ -17,7 +17,7 @@
         type="submit"
         :loading="submitting"
         :disable="isFolderWithChildren && !confirmDelete"
-        data-cy="delete-file-submit"
+        data-cy="submit-button"
         color="negative"
       >
         <template v-slot:loading>

--- a/src/components/form/DeleteFileForm.vue
+++ b/src/components/form/DeleteFileForm.vue
@@ -1,14 +1,14 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="delete-file-form"
     class="q-gutter-md delete-file-form"
+    data-cy="delete-file-form"
   >
     <q-checkbox
       v-if="isFolderWithChildren"
       v-model="confirmDelete"
-      data-cy="confirm-delete-checkbox"
       :label="$t('page.modelizer.fileExplorer.delete.folder.confirmDelete')"
+      data-cy="confirm-delete-checkbox"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -17,8 +17,8 @@
         type="submit"
         :loading="submitting"
         :disable="isFolderWithChildren && !confirmDelete"
-        data-cy="submit-button"
         color="negative"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/DeleteModelForm.vue
+++ b/src/components/form/DeleteModelForm.vue
@@ -1,8 +1,8 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="delete-model-form"
     class="q-gutter-md delete-model-form"
+    data-cy="delete-model-form"
   >
     <div class="flex row items-center justify-center">
       {{$t('actions.models.delete.form.message')}}
@@ -13,8 +13,8 @@
         :label="$t('actions.default.delete')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="negative"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/DeleteModelForm.vue
+++ b/src/components/form/DeleteModelForm.vue
@@ -13,7 +13,7 @@
         :label="$t('actions.default.delete')"
         type="submit"
         :loading="submitting"
-        data-cy="delete-model-submit"
+        data-cy="submit-button"
         color="negative"
       >
         <template v-slot:loading>

--- a/src/components/form/DeleteProjectForm.vue
+++ b/src/components/form/DeleteProjectForm.vue
@@ -6,11 +6,11 @@
   >
     <q-checkbox
       v-model="confirmDelete"
-      data-cy="confirm-delete-checkbox"
       :label="$t(
         'actions.home.deleteProject.confirmDelete',
         { name: props.projectId },
       )"
+      data-cy="confirm-delete-checkbox"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -19,8 +19,8 @@
         icon="fa-solid fa-trash"
         type="submit"
         :disable="!confirmDelete"
-        data-cy="submit-button"
         color="negative"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots />

--- a/src/components/form/DeleteProjectForm.vue
+++ b/src/components/form/DeleteProjectForm.vue
@@ -6,7 +6,7 @@
   >
     <q-checkbox
       v-model="confirmDelete"
-      data-cy="confirm-delete-project-checkbox"
+      data-cy="confirm-delete-checkbox"
       :label="$t(
         'actions.home.deleteProject.confirmDelete',
         { name: props.projectId },
@@ -19,7 +19,7 @@
         icon="fa-solid fa-trash"
         type="submit"
         :disable="!confirmDelete"
-        data-cy="delete-project-form-submit"
+        data-cy="submit-button"
         color="negative"
       >
         <template v-slot:loading>

--- a/src/components/form/GitAddRemoteForm.vue
+++ b/src/components/form/GitAddRemoteForm.vue
@@ -17,7 +17,7 @@
       v-model="repository"
       :label="$t('page.modelizer.settings.gitAddRemote.repository')"
       lazy-rules
-      data-cy="git-repository-input"
+      data-cy="repository-input"
       :hint="$t('page.modelizer.settings.gitAddRemote.repositoryExample')"
       :rules="[v => notEmpty($t, v), v => isGitRepositoryUrl($t, v)]"
     />
@@ -27,8 +27,9 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="git-form-submit"
-        color="positive">
+        data-cy="submit-button"
+        color="positive"
+      >
         <template v-slot:loading>
           <q-spinner-dots/>
         </template>

--- a/src/components/form/GitAddRemoteForm.vue
+++ b/src/components/form/GitAddRemoteForm.vue
@@ -1,8 +1,8 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="git-add-remote-form"
     class="q-gutter-md"
+    data-cy="git-add-remote-form"
   >
     <div class="warning-message row items-center bg-warning q-py-sm">
       <q-icon
@@ -17,9 +17,9 @@
       v-model="repository"
       :label="$t('page.modelizer.settings.gitAddRemote.repository')"
       lazy-rules
-      data-cy="repository-input"
       :hint="$t('page.modelizer.settings.gitAddRemote.repositoryExample')"
       :rules="[v => notEmpty($t, v), v => isGitRepositoryUrl($t, v)]"
+      data-cy="repository-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -27,8 +27,8 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitAuthenticationForm.vue
+++ b/src/components/form/GitAuthenticationForm.vue
@@ -1,8 +1,8 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="git-authentication-form"
     class="q-gutter-md git-authentication-form"
+    data-cy="git-authentication-form"
   >
     <q-input
       filled
@@ -22,8 +22,9 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
+        color="positive"
         data-cy="submit-button"
-        color="positive">
+      >
         <template v-slot:loading>
           <q-spinner-dots/>
         </template>

--- a/src/components/form/GitAuthenticationForm.vue
+++ b/src/components/form/GitAuthenticationForm.vue
@@ -8,13 +8,13 @@
       filled
       v-model="username"
       :label="$t('page.modelizer.settings.gitAuthentication.username')"
-      data-cy="git-username-input"
+      data-cy="username-input"
     />
     <q-input
       filled
       v-model="token"
       :label="$t('page.modelizer.settings.gitAuthentication.token')"
-      data-cy="git-token-input"
+      data-cy="token-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -22,7 +22,7 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="git-form-submit"
+        data-cy="submit-button"
         color="positive">
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitCommitForm.vue
+++ b/src/components/form/GitCommitForm.vue
@@ -10,7 +10,7 @@
       v-model="message"
       :label="$t('page.modelizer.git.commit.message')"
       lazy-rules
-      data-cy="git-message-input"
+      data-cy="message-input"
       :rules="[(v) => notEmpty(t, v)]"
     />
     <div class="flex row items-center justify-center">
@@ -19,7 +19,7 @@
         :label="$t('actions.git.commit')"
         :loading="submitting"
         type="submit"
-        data-cy="git-form-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/GitCommitForm.vue
+++ b/src/components/form/GitCommitForm.vue
@@ -2,16 +2,16 @@
   <q-form
     ref="form"
     @submit="onSubmit"
-    data-cy="git-commit-form"
     class="q-gutter-md git-commit-form"
+    data-cy="git-commit-form"
   >
     <q-input
       filled
       v-model="message"
       :label="$t('page.modelizer.git.commit.message')"
       lazy-rules
-      data-cy="message-input"
       :rules="[(v) => notEmpty(t, v)]"
+      data-cy="message-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -19,8 +19,8 @@
         :label="$t('actions.git.commit')"
         :loading="submitting"
         type="submit"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitNewBranchForm.vue
+++ b/src/components/form/GitNewBranchForm.vue
@@ -2,21 +2,21 @@
   <q-form
     ref="form"
     @submit="onSubmit"
-    data-cy="git-new-branch-form"
     class="q-gutter-md git-new-branch-form"
+    data-cy="git-new-branch-form"
   >
     <q-input
       filled
       v-model="newBranch"
       :label="$t('page.modelizer.git.newBranch.branch')"
       lazy-rules
-      data-cy="branch-name-input"
       :rules="[(v) => notEmpty(t, v), (v) => isUniqueBranchName(t, branches, v)]"
+      data-cy="branch-name-input"
     />
     <q-checkbox
       v-model="checkout"
-      data-cy="checkout-checkbox"
       :label="$t('page.modelizer.git.newBranch.checkout')"
+      data-cy="checkout-checkbox"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -24,8 +24,8 @@
         :label="$t('actions.default.create')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitNewBranchForm.vue
+++ b/src/components/form/GitNewBranchForm.vue
@@ -2,20 +2,20 @@
   <q-form
     ref="form"
     @submit="onSubmit"
-    data-cy="git-newBranch-form"
-    class="q-gutter-md git-newBranch-form"
+    data-cy="git-new-branch-form"
+    class="q-gutter-md git-new-branch-form"
   >
     <q-input
       filled
       v-model="newBranch"
       :label="$t('page.modelizer.git.newBranch.branch')"
       lazy-rules
-      data-cy="git-branch-input"
+      data-cy="branch-name-input"
       :rules="[(v) => notEmpty(t, v), (v) => isUniqueBranchName(t, branches, v)]"
     />
     <q-checkbox
       v-model="checkout"
-      data-cy="git-checkout-checkbox"
+      data-cy="checkout-checkbox"
       :label="$t('page.modelizer.git.newBranch.checkout')"
     />
     <div class="flex row items-center justify-center">
@@ -24,7 +24,7 @@
         :label="$t('actions.default.create')"
         type="submit"
         :loading="submitting"
-        data-cy="git-form-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/GitPushForm.vue
+++ b/src/components/form/GitPushForm.vue
@@ -2,8 +2,8 @@
   <q-form
     ref="form"
     @submit="onSubmit"
-    data-cy="git-push-form"
     class="q-gutter-md git-push-form"
+    data-cy="git-push-form"
   >
     <div v-html="$t('page.modelizer.git.push.description', { branch: branchName })"></div>
     <q-checkbox
@@ -18,8 +18,8 @@
         :label="$t('actions.git.push')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitPushForm.vue
+++ b/src/components/form/GitPushForm.vue
@@ -8,7 +8,7 @@
     <div v-html="$t('page.modelizer.git.push.description', { branch: branchName })"></div>
     <q-checkbox
       v-model="force"
-      data-cy="git-force-checkbox"
+      data-cy="force-checkbox"
     >
       <span v-html="$t('page.modelizer.git.push.force', { branch: branchName })"></span>
     </q-checkbox>
@@ -18,7 +18,7 @@
         :label="$t('actions.git.push')"
         type="submit"
         :loading="submitting"
-        data-cy="git-form-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/GitUpdateForm.vue
+++ b/src/components/form/GitUpdateForm.vue
@@ -2,8 +2,8 @@
   <q-form
     ref="form"
     @submit="onSubmit"
-    data-cy="git-update-form"
     class="q-gutter-md git-update-form"
+    data-cy="git-update-form"
   >
     <div v-html="$t('page.modelizer.git.update.description', { branch: branchName })"></div>
     <q-checkbox
@@ -18,8 +18,8 @@
         :label="$t('actions.default.update')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/GitUpdateForm.vue
+++ b/src/components/form/GitUpdateForm.vue
@@ -8,7 +8,7 @@
     <div v-html="$t('page.modelizer.git.update.description', { branch: branchName })"></div>
     <q-checkbox
       v-model="fastForward"
-      data-cy="git-fastForward-checkbox"
+      data-cy="fast-forward-checkbox"
     >
       <span v-html="$t('page.modelizer.git.update.fastForward')"></span>
     </q-checkbox>
@@ -18,7 +18,7 @@
         :label="$t('actions.default.update')"
         type="submit"
         :loading="submitting"
-        data-cy="git-form-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/ImportModelTemplateForm.vue
+++ b/src/components/form/ImportModelTemplateForm.vue
@@ -12,7 +12,7 @@
       :rules="[
         (v) => notEmpty($t, v),
       ]"
-      data-cy="import-model-template-name-input"
+      data-cy="name-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -21,7 +21,7 @@
         type="submit"
         :loading="submitting"
         color="positive"
-        data-cy="import-model-template-submit"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/ImportProjectForm.vue
+++ b/src/components/form/ImportProjectForm.vue
@@ -11,21 +11,21 @@
       :rules="[v => notEmpty($t, v), v => isGitRepositoryUrl($t, v)]"
       filled
       lazy-rules
-      data-cy="git-repository-input"
+      data-cy="repository-input"
     />
     <q-input
       v-model="username"
       :label="$t('page.modelizer.settings.gitAuthentication.username')"
       filled
       lazy-rules
-      data-cy="git-username-input"
+      data-cy="username-input"
     />
     <q-input
       v-model="token"
       :label="$t('page.modelizer.settings.gitAuthentication.token')"
       filled
       lazy-rules
-      data-cy="git-token-input"
+      data-cy="token-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -33,7 +33,7 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
-        data-cy="import-project-form-submit"
+        data-cy="submit-button"
         color="positive">
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/ImportProjectForm.vue
+++ b/src/components/form/ImportProjectForm.vue
@@ -33,8 +33,9 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
+        color="positive"
         data-cy="submit-button"
-        color="positive">
+      >
         <template v-slot:loading>
           <q-spinner-dots/>
         </template>

--- a/src/components/form/NewProjectForm.vue
+++ b/src/components/form/NewProjectForm.vue
@@ -13,14 +13,14 @@
       ]"
       filled
       lazy-rules
-      data-cy="project-name-input"
+      data-cy="name-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
         :label="$t(`actions.home.createProject`)"
         icon="fa-solid fa-save"
         type="submit"
-        data-cy="new-project-form-submit"
+        data-cy="submit-button"
         color="positive">
       </q-btn>
     </div>

--- a/src/components/form/NewProjectTemplateForm.vue
+++ b/src/components/form/NewProjectTemplateForm.vue
@@ -13,12 +13,13 @@
       ]"
       filled
       lazy-rules
-      data-cy="project-name-input"
+      data-cy="name-input"
     />
     <q-checkbox
       v-model="localIsChecked"
       class="q-mb-sm"
       :label="$t('page.home.template.import')"
+      data-cy="import-project-checkbox"
     />
     <template
       v-if="isChecked"
@@ -30,21 +31,21 @@
         :rules="[v => notEmpty($t, v), v => isGitRepositoryUrl($t, v)]"
         filled
         lazy-rules
-        data-cy="git-repository-input"
+        data-cy="repository-input"
       />
       <q-input
         v-model="username"
         :label="$t('page.modelizer.settings.gitAuthentication.username')"
         filled
         lazy-rules
-        data-cy="git-username-input"
+        data-cy="username-input"
       />
       <q-input
         v-model="token"
         :label="$t('page.modelizer.settings.gitAuthentication.token')"
         filled
         lazy-rules
-        data-cy="git-token-input"
+        data-cy="token-input"
       />
     </template>
     <div class="flex row items-center justify-center">
@@ -53,7 +54,7 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
-        data-cy="new-project-template-form-submit"
+        data-cy="submit-button"
         color="positive">
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/RenameModelForm.vue
+++ b/src/components/form/RenameModelForm.vue
@@ -1,18 +1,18 @@
 <template>
   <q-form
     @submit="onSubmit"
-    data-cy="rename-model-form"
     class="q-gutter-md rename-model-form"
+    data-cy="rename-model-form"
   >
     <q-input
       v-model="modelName"
       filled
       :label="$t('actions.models.rename.form.name')"
       lazy-rules
-      data-cy="name-input"
       :rules="[
         (v) => notEmpty($t, v),
       ]"
+      data-cy="name-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -20,8 +20,8 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="submit-button"
         color="positive"
+        data-cy="submit-button"
       >
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/form/RenameModelForm.vue
+++ b/src/components/form/RenameModelForm.vue
@@ -9,7 +9,7 @@
       filled
       :label="$t('actions.models.rename.form.name')"
       lazy-rules
-      data-cy="rename-model-name-input"
+      data-cy="name-input"
       :rules="[
         (v) => notEmpty($t, v),
       ]"
@@ -20,7 +20,7 @@
         :label="$t('actions.default.save')"
         type="submit"
         :loading="submitting"
-        data-cy="rename-model-submit"
+        data-cy="submit-button"
         color="positive"
       >
         <template v-slot:loading>

--- a/src/components/form/RenameProjectForm.vue
+++ b/src/components/form/RenameProjectForm.vue
@@ -21,8 +21,9 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
+        color="positive"
         data-cy="submit-button"
-        color="positive">
+      >
         <template v-slot:loading>
           <q-spinner-dots/>
         </template>

--- a/src/components/form/RenameProjectForm.vue
+++ b/src/components/form/RenameProjectForm.vue
@@ -13,7 +13,7 @@
       ]"
       filled
       lazy-rules
-      data-cy="git-project-name-input"
+      data-cy="name-input"
     />
     <div class="flex row items-center justify-center">
       <q-btn
@@ -21,7 +21,7 @@
         :loading="submitting"
         icon="fa-solid fa-save"
         type="submit"
-        data-cy="rename-project-form-submit"
+        data-cy="submit-button"
         color="positive">
         <template v-slot:loading>
           <q-spinner-dots/>

--- a/src/components/grid/ProjectGrid.vue
+++ b/src/components/grid/ProjectGrid.vue
@@ -9,9 +9,9 @@
           class="q-ml-xl"
           color="primary"
           icon="fa-solid fa-plus"
-          data-cy="create-project-button"
           :label="$t('actions.home.newProject')"
           @click="DialogEvent.next({ type: 'open', key: 'CreateProject' })"
+          data-cy="create-project-button"
         />
         <q-btn
           outline
@@ -19,9 +19,9 @@
           class="q-ml-sm"
           color="primary"
           icon="fa-solid fa-cloud-arrow-down"
-          data-cy="import-project-button"
           :label="$t('actions.home.importProject')"
           @click="DialogEvent.next({ type: 'open', key: 'ImportProject' })"
+          data-cy="import-project-button"
         />
       </div>
       <div class="row">

--- a/src/components/grid/ProjectGrid.vue
+++ b/src/components/grid/ProjectGrid.vue
@@ -9,9 +9,9 @@
           class="q-ml-xl"
           color="primary"
           icon="fa-solid fa-plus"
-          data-cy="new-project-button"
+          data-cy="create-project-button"
           :label="$t('actions.home.newProject')"
-          @click="DialogEvent.next({ type: 'open', key: 'NewProject' })"
+          @click="DialogEvent.next({ type: 'open', key: 'CreateProject' })"
         />
         <q-btn
           outline

--- a/src/components/grid/ProjectGrid.vue
+++ b/src/components/grid/ProjectGrid.vue
@@ -9,7 +9,7 @@
           class="q-ml-xl"
           color="primary"
           icon="fa-solid fa-plus"
-          data-cy="new-project"
+          data-cy="new-project-button"
           :label="$t('actions.home.newProject')"
           @click="DialogEvent.next({ type: 'open', key: 'NewProject' })"
         />
@@ -19,7 +19,7 @@
           class="q-ml-sm"
           color="primary"
           icon="fa-solid fa-cloud-arrow-down"
-          data-cy="import-project"
+          data-cy="import-project-button"
           :label="$t('actions.home.importProject')"
           @click="DialogEvent.next({ type: 'open', key: 'ImportProject' })"
         />

--- a/src/components/grid/ProjectGrid.vue
+++ b/src/components/grid/ProjectGrid.vue
@@ -25,7 +25,7 @@
         />
       </div>
       <div class="row">
-        <ProjectCard
+        <project-card
           v-for="project in projects"
           :key="project.id"
           :project="project"

--- a/src/components/grid/TemplateGrid.vue
+++ b/src/components/grid/TemplateGrid.vue
@@ -5,7 +5,7 @@
         <slot name="header"></slot>
       </div>
       <div class="row">
-        <TemplateCard
+        <template-card
           v-for="template in templates"
           :key="template.key"
           :template="template"

--- a/src/components/inputs/AttributesList.vue
+++ b/src/components/inputs/AttributesList.vue
@@ -1,10 +1,10 @@
 <template>
-  <q-list>
+  <q-list data-cy="attributes-list">
     <slot name="header"></slot>
     <!-- Attributes not Object -->
     <q-item
       v-for="attribute in data.localAttributes.filter(({ type }) => type !== 'Object')"
-      :key="attribute.title"
+      :key="attribute.name"
       class="q-px-none"
     >
       <input-wrapper
@@ -31,14 +31,14 @@
         :label="$t('plugin.component.attribute.add')"
         color="positive"
         icon="fa-solid fa-plus"
-        data-cy="object-details-panel-attribute-add-button"
+        data-cy="add-button"
         @click="addAttribute"
       />
     </q-item>
     <!-- Attributes Object -->
     <q-item
       v-for="attribute in data.localAttributes.filter(({ type }) => type === 'Object')"
-      :key="attribute.title"
+      :key="attribute.name"
       class="q-pa-none"
       dense
     >

--- a/src/components/inputs/AttributesList.vue
+++ b/src/components/inputs/AttributesList.vue
@@ -31,8 +31,8 @@
         :label="$t('plugin.component.attribute.add')"
         color="positive"
         icon="fa-solid fa-plus"
-        data-cy="add-button"
         @click="addAttribute"
+        data-cy="add-button"
       />
     </q-item>
     <!-- Attributes Object -->

--- a/src/components/inputs/InputWrapper.vue
+++ b/src/components/inputs/InputWrapper.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="row items-baseline">
+  <div
+    class="row items-baseline"
+  >
     <template v-if="!attribute.definition">
       <q-input
         v-model="name"
@@ -48,7 +50,7 @@
       flat
       color="negative"
       icon="fa-solid fa-trash"
-      data-cy="object-details-panel-attribute-delete-button"
+      data-cy="delete-attribute-button"
       @click="emit('delete:attribute')"
     >
       <q-tooltip anchor="center left" self="center right">

--- a/src/components/inputs/InputWrapper.vue
+++ b/src/components/inputs/InputWrapper.vue
@@ -50,8 +50,8 @@
       flat
       color="negative"
       icon="fa-solid fa-trash"
-      data-cy="delete-attribute-button"
       @click="emit('delete:attribute')"
+      data-cy="delete-attribute-button"
     >
       <q-tooltip anchor="center left" self="center right">
         {{$t('plugin.component.attribute.delete')}}

--- a/src/components/menu/FileExplorerActionMenu.vue
+++ b/src/components/menu/FileExplorerActionMenu.vue
@@ -9,8 +9,8 @@
       <template v-if="file.isFolder">
         <q-item
           clickable
-          data-cy="create-folder-action-item"
           @click="createFile(true)"
+          data-cy="create-folder-action-item"
         >
           <q-item-section avatar>
             <q-icon
@@ -25,8 +25,8 @@
         </q-item>
         <q-item
           clickable
-          data-cy="create-file-action-item"
           @click="createFile(false)"
+          data-cy="create-file-action-item"
         >
           <q-item-section avatar>
             <q-icon
@@ -43,8 +43,8 @@
       <template v-if="isFile && allowGitAdd">
         <q-item
           clickable
-          data-cy="git-add-file-action-item"
           @click="addFile(file)"
+          data-cy="git-add-file-action-item"
         >
           <q-item-section avatar>
             <q-icon
@@ -59,16 +59,16 @@
         </q-item>
         <q-linear-progress
           v-if="loading.add"
-          data-cy="git-add-loader"
           color="primary"
           indeterminate
+          data-cy="git-add-loader"
         />
       </template>
       <q-item
         v-if="!file.isRootFolder"
         clickable
-        data-cy="delete-file-action-item"
         @click="deleteFile"
+        data-cy="delete-file-action-item"
       >
         <q-item-section avatar>
           <q-icon

--- a/src/components/menu/FileExplorerActionMenu.vue
+++ b/src/components/menu/FileExplorerActionMenu.vue
@@ -7,26 +7,32 @@
   >
     <q-list style="min-width: 150px">
       <template v-if="file.isFolder">
-        <q-item clickable @click="createFile(true)">
+        <q-item
+          clickable
+          data-cy="create-folder-action-item"
+          @click="createFile(true)"
+        >
           <q-item-section avatar>
             <q-icon
               color="primary"
               size="xs"
               name="fa-solid fa-folder-plus"
-              data-cy="file-explorer-menu-create-folder"
             />
           </q-item-section>
           <q-item-section>
             {{ $t('actions.fileExplorer.newFolder') }}
           </q-item-section>
         </q-item>
-        <q-item clickable @click="createFile(false)">
+        <q-item
+          clickable
+          data-cy="create-file-action-item"
+          @click="createFile(false)"
+        >
           <q-item-section avatar>
             <q-icon
               color="primary"
               size="xs"
               name="fa-solid fa-file-circle-plus"
-              data-cy="file-explorer-menu-create-file"
             />
           </q-item-section>
           <q-item-section>
@@ -37,6 +43,7 @@
       <template v-if="isFile && allowGitAdd">
         <q-item
           clickable
+          data-cy="git-add-file-action-item"
           @click="addFile(file)"
         >
           <q-item-section avatar>
@@ -44,7 +51,6 @@
               color="primary"
               size="xs"
               name="fa-solid fa-plus"
-              data-cy="file-explorer-menu-add-file"
             />
           </q-item-section>
           <q-item-section>
@@ -53,18 +59,22 @@
         </q-item>
         <q-linear-progress
           v-if="loading.add"
-          data-cy="file-explorer-menu-add-loader"
+          data-cy="git-add-loader"
           color="primary"
           indeterminate
         />
       </template>
-      <q-item v-if="!file.isRootFolder" clickable @click="deleteFile">
+      <q-item
+        v-if="!file.isRootFolder"
+        clickable
+        data-cy="delete-file-action-item"
+        @click="deleteFile"
+      >
         <q-item-section avatar>
           <q-icon
             color="primary"
             size="xs"
             name="fa-solid fa-trash"
-            data-cy="file-explorer-menu-delete-file"
           />
         </q-item-section>
         <q-item-section>

--- a/src/components/menu/GitBranchActionMenu.vue
+++ b/src/components/menu/GitBranchActionMenu.vue
@@ -6,22 +6,22 @@
     <q-list>
       <q-item
         v-if="!isCurrentBranch"
-        :data-cy="`checkout_${branchName}`"
         clickable
         @click="onCheckout"
+        :data-cy="`checkout_${branchName}`"
       >
         <q-item-section>{{ $t('actions.git.checkout') }}</q-item-section>
       </q-item>
       <q-linear-progress
         v-if="!isCurrentBranch && loading.checkout"
-        :data-cy="`checkout-loader_${branchName}`"
         color="primary"
         indeterminate
+        :data-cy="`checkout-loader_${branchName}`"
       />
       <q-item
-        :data-cy="`new-branch_${branchName}`"
         clickable
         @click="openDialog('GitNewBranch')"
+        :data-cy="`new-branch_${branchName}`"
       >
         <q-item-section>
           {{ $t('actions.git.newBranchFrom', { branch: branchName }) }}
@@ -32,9 +32,9 @@
 
       <q-item
         v-if="onLocal && onRemote"
-        :data-cy="`update_${branchName}`"
         clickable
         @click="openDialog('GitUpdate')"
+        :data-cy="`update_${branchName}`"
       >
         <q-item-section>
           {{ $t('actions.git.update') }}
@@ -43,9 +43,9 @@
 
       <q-item
         v-if="onLocal"
-        :data-cy="`push_${branchName}`"
         clickable
         @click="openDialog('GitPush')"
+        :data-cy="`push_${branchName}`"
       >
         <q-item-section>
           {{ $t('actions.git.push') }}

--- a/src/components/menu/GitBranchActionMenu.vue
+++ b/src/components/menu/GitBranchActionMenu.vue
@@ -1,9 +1,12 @@
 <template>
-  <q-menu ref="menu">
+  <q-menu
+    ref="menu"
+    data-cy="git-branch-action-menu"
+  >
     <q-list>
       <q-item
         v-if="!isCurrentBranch"
-        :data-cy="`git-menu-branch-checkout-${branchName}`"
+        :data-cy="`checkout_${branchName}`"
         clickable
         @click="onCheckout"
       >
@@ -11,12 +14,12 @@
       </q-item>
       <q-linear-progress
         v-if="!isCurrentBranch && loading.checkout"
-        :data-cy="`git-menu-branch-checkout-loader-${branchName}`"
+        :data-cy="`checkout-loader_${branchName}`"
         color="primary"
         indeterminate
       />
       <q-item
-        :data-cy="`git-menu-branch-new-branch-${branchName}`"
+        :data-cy="`new-branch_${branchName}`"
         clickable
         @click="openDialog('GitNewBranch')"
       >
@@ -29,7 +32,7 @@
 
       <q-item
         v-if="onLocal && onRemote"
-        :data-cy="`git-menu-branch-update-${branchName}`"
+        :data-cy="`update_${branchName}`"
         clickable
         @click="openDialog('GitUpdate')"
       >
@@ -40,7 +43,7 @@
 
       <q-item
         v-if="onLocal"
-        :data-cy="`git-menu-branch-push-${branchName}`"
+        :data-cy="`push_${branchName}`"
         clickable
         @click="openDialog('GitPush')"
       >

--- a/src/components/menu/GitBranchExpandListMenu.vue
+++ b/src/components/menu/GitBranchExpandListMenu.vue
@@ -1,13 +1,14 @@
 <template>
   <q-item clickable class="text-weight-bold text-grey-7">
     <q-item-section avatar/>
-    <q-item-section data-cy="git-branch-expand-menu-text">
+    <q-item-section data-cy="expand-list-text">
       {{ $t(open ? 'actions.default.show.less' : 'actions.default.show.more', { number }) }}
     </q-item-section>
   </q-item>
 </template>
 
 <script setup>
+// TODO : Rename file
 defineProps({
   open: {
     type: Boolean,

--- a/src/components/menu/GitBranchItemMenu.vue
+++ b/src/components/menu/GitBranchItemMenu.vue
@@ -2,9 +2,9 @@
   <q-item clickable>
     <q-item-section avatar>
       <q-icon
+        v-if="isCurrentBranch"
         color="primary"
         name="fa-solid fa-tag"
-        v-if="isCurrentBranch"
         data-cy="git-menu-current-branch"
       >
         <q-tooltip>

--- a/src/components/menu/GitBranchMenu.vue
+++ b/src/components/menu/GitBranchMenu.vue
@@ -9,7 +9,7 @@
     <q-list style="min-width: 500px">
       <q-input
         ref="searchInput"
-        data-cy="git-branch-menu-search-bar"
+        data-cy="search-branch-input"
         v-model="searchedBranch"
         dense
         clearable
@@ -18,43 +18,61 @@
           <q-icon name="fa-solid fa-magnifying-glass" />
         </template>
       </q-input>
-      <q-item clickable @click="openDialog('GitStatus')">
+      <q-item
+        clickable
+        @click="openDialog('GitStatus')"
+        data-cy="git-status-item"
+      >
         <q-item-section avatar>
           <q-icon
             color="primary"
             name="fa-solid fa-question"
-            data-cy="git-menu-status"
           />
         </q-item-section>
-        <q-item-section>{{ $t('actions.git.status') }}</q-item-section>
+        <q-item-section>
+          {{ $t('actions.git.status') }}
+        </q-item-section>
       </q-item>
-      <q-item clickable @click="openDialog('GitCommit')">
+      <q-item
+        clickable
+        @click="openDialog('GitCommit')"
+        data-cy="git-commit-item"
+      >
         <q-item-section avatar>
           <q-icon
             color="primary"
             name="fa-solid fa-floppy-disk"
-            data-cy="git-menu-commit"
           />
         </q-item-section>
-        <q-item-section>{{ $t('actions.git.commit') }}</q-item-section>
+        <q-item-section>
+          {{ $t('actions.git.commit') }}
+        </q-item-section>
       </q-item>
-      <q-item clickable @click="openDialog('GitNewBranch')">
+      <q-item
+        clickable
+        @click="openDialog('GitNewBranch')"
+        data-cy="git-new-branch-item"
+      >
         <q-item-section avatar>
           <q-icon
             color="primary"
             name="fa-solid fa-plus"
-            data-cy="git-menu-new-branch"
           />
         </q-item-section>
-        <q-item-section>{{ $t('actions.git.newBranch') }}</q-item-section>
+        <q-item-section>
+          {{ $t('actions.git.newBranch') }}
+        </q-item-section>
       </q-item>
 
-      <q-item clickable @click="openDialog('GitLog')">
+      <q-item
+        clickable
+        @click="openDialog('GitLog')"
+        data-cy="git-log-item"
+      >
         <q-item-section avatar>
           <q-icon
             color="primary"
             name="fa-solid fa-list"
-            data-cy="git-menu-log"
           />
         </q-item-section>
         <q-item-section>{{ $t('actions.git.log') }}</q-item-section>
@@ -64,22 +82,22 @@
         <git-branch-header-menu :title="$t('menu.git.localBranchesTitle')"/>
         <template v-for="(branch, index) in localBranches">
           <git-branch-item-menu
+            v-if="showLocal || index < maxItem"
             :key="`local_${branch.name}`"
             :name="branch.name"
             :full-name="branch.fullName"
             :isCurrentBranch="branch.name === currentBranchName"
             :on-local="branch.onLocal"
             :on-remote="branch.onRemote"
-            v-if="showLocal || index < maxItem"
             @action:done="menu.hide()"
-            :data-cy="`git-menu-branch-local-${branch.name}`"
+            :data-cy="`local-branch_${branch.name}`"
           />
         </template>
         <git-branch-expand-list-menu
-          data-cy="git-branch-expand-local-menu"
+          v-if="localBranches.length > maxItem"
+          data-cy="expand-local-branch-menu"
           :open="showLocal"
           :number="localBranches.length - maxItem"
-          v-if="localBranches.length > maxItem"
           @click="manageExpandMenu(true)"
         />
       </template>
@@ -88,22 +106,22 @@
         <git-branch-header-menu :title="$t('menu.git.remoteBranchesTitle')"/>
         <template v-for="(branch, index) in remoteBranches">
           <git-branch-item-menu
+            v-if="showRemote || index < maxItem"
             :key="`remote_${branch.name}`"
             :name="branch.name"
             :full-name="branch.fullName"
             :isCurrentBranch="branch.name === currentBranchName"
             :on-local="branch.onLocal"
             :on-remote="branch.onRemote"
-            v-if="showRemote || index < maxItem"
             @action:done="menu.hide()"
-            :data-cy="`git-menu-branch-remote-${branch.name}`"
+            :data-cy="`remote-branch_${branch.name}`"
           />
         </template>
         <git-branch-expand-list-menu
-          data-cy="git-branch-expand-remote-menu"
+          v-if="remoteBranches.length > maxItem"
+          data-cy="expand-remote-branch-menu"
           :open="showRemote"
           :number="remoteBranches.length - maxItem"
-          v-if="remoteBranches.length > maxItem"
           @click="manageExpandMenu(false)"
         />
       </template>

--- a/src/components/menu/GitBranchMenu.vue
+++ b/src/components/menu/GitBranchMenu.vue
@@ -1,18 +1,18 @@
 <template>
   <q-menu
     class="git-branch-menu"
-    data-cy="git-branch-menu"
     ref="menu"
     @before-show="onOpen"
     @show="onShow"
+    data-cy="git-branch-menu"
   >
     <q-list style="min-width: 500px">
       <q-input
         ref="searchInput"
-        data-cy="search-branch-input"
         v-model="searchedBranch"
         dense
         clearable
+        data-cy="search-branch-input"
       >
         <template v-slot:prepend>
           <q-icon name="fa-solid fa-magnifying-glass" />
@@ -95,10 +95,10 @@
         </template>
         <git-branch-expand-list-menu
           v-if="localBranches.length > maxItem"
-          data-cy="expand-local-branch-menu"
           :open="showLocal"
           :number="localBranches.length - maxItem"
           @click="manageExpandMenu(true)"
+          data-cy="expand-local-branch-menu"
         />
       </template>
 
@@ -119,10 +119,10 @@
         </template>
         <git-branch-expand-list-menu
           v-if="remoteBranches.length > maxItem"
-          data-cy="expand-remote-branch-menu"
           :open="showRemote"
           :number="remoteBranches.length - maxItem"
           @click="manageExpandMenu(false)"
+          data-cy="expand-remote-branch-menu"
         />
       </template>
 

--- a/src/components/menu/ModelizerSettingsMenu.vue
+++ b/src/components/menu/ModelizerSettingsMenu.vue
@@ -4,7 +4,7 @@
     color="white"
     text-color="primary"
     icon="fa-solid fa-gear"
-    data-cy="project-settings"
+    data-cy="modelizer-settings-button"
   >
     <q-menu
       auto-close
@@ -19,7 +19,7 @@
             v-if="menuItem.visible"
             clickable
             class="settings-item"
-            :data-cy="`git-settings-menu-${menuItem.key}`"
+            :data-cy="`item_${menuItem.key}`"
             @click="onClick(menuItem.key)"
           >
             <q-item-section avatar>

--- a/src/components/menu/ModelizerSettingsMenu.vue
+++ b/src/components/menu/ModelizerSettingsMenu.vue
@@ -19,8 +19,8 @@
             v-if="menuItem.visible"
             clickable
             class="settings-item"
-            :data-cy="`item_${menuItem.key}`"
             @click="onClick(menuItem.key)"
+            :data-cy="`item_${menuItem.key}`"
           >
             <q-item-section avatar>
               <q-icon color="primary" :name="menuItem.icon" />

--- a/src/components/tab/FileTabHeader.vue
+++ b/src/components/tab/FileTabHeader.vue
@@ -21,7 +21,7 @@
         icon="fa-solid fa-xmark"
         class="q-ml-sm"
         @click.stop="emit('update:close-file', file.id)"
-        data-cy="close-file-tab"
+        data-cy="close-button"
       />
     </div>
   </q-tab>

--- a/src/components/tab/FileTabs.vue
+++ b/src/components/tab/FileTabs.vue
@@ -22,7 +22,7 @@
         v-for="file in fileTabArray"
         :key="file.id"
         :name="file.id"
-        :data-cy="`file-tab-content-${file.label}`"
+        :data-cy="`file-tab-panel_${file.label}`"
       >
         <slot :file="file"></slot>
       </q-tab-panel>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -205,8 +205,8 @@ export default {
     home: {
       project: {
         title: 'Recent projects',
-        import: 'Import project',
-        create: 'Create project',
+        import: 'Import new project',
+        create: 'Create new project',
         rename: 'Rename project',
         name: 'Project name',
         empty: 'No projects, please create a new project to have one here 😉',

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,12 +1,12 @@
 <template>
   <q-page
     class="about-page"
-    data-cy="modelizer-page"
+    data-cy="about-page"
   >
     <div class="row col-md-6 justify-center items-center bg-primary about-banner">
       <router-link
         class="col-1"
-        data-cy="go-to-homepage"
+        data-cy="home-page-link"
         to="/"
       >
         <q-img
@@ -28,6 +28,7 @@
           to="/"
           :label="$t('actions.default.goToHome')"
           no-caps
+          data-cy="home-page-button"
         />
       </div>
       <section class="fit row justify-center">

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -6,8 +6,8 @@
     <div class="row col-md-6 justify-center items-center bg-primary about-banner">
       <router-link
         class="col-1"
-        data-cy="home-page-link"
         to="/"
+        data-cy="home-page-link"
       >
         <q-img
           src="icons/logo_modelizer.svg"

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -12,13 +12,13 @@
     </div>
     <div class="column items-center home-content">
       <div class="fit row justify-center">
-        <ProjectGrid
+        <project-grid
           class="col-md-8"
           :projects="projects"
         />
       </div>
       <div class="fit row justify-center q-mt-lg">
-        <TemplateGrid
+        <template-grid
           class="col-md-8"
           :templates="templates"
           @add:template="openCreateProjectTemplateDialog"
@@ -26,7 +26,7 @@
           <template v-slot:header>
             <h4>{{ $t('page.home.template.createProject') }}</h4>
           </template>
-        </TemplateGrid>
+        </template-grid>
       </div>
     </div>
     <import-project-dialog/>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -21,7 +21,7 @@
         <TemplateGrid
           class="col-md-8"
           :templates="templates"
-          @add:template="openNewProjectTemplateDialog"
+          @add:template="openCreateProjectTemplateDialog"
         >
           <template v-slot:header>
             <h4>{{ $t('page.home.template.createProject') }}</h4>
@@ -30,7 +30,7 @@
       </div>
     </div>
     <import-project-dialog/>
-    <new-project-template-dialog/>
+    <create-project-template-dialog/>
     <create-project-dialog/>
     <delete-project-dialog/>
     <rename-project-dialog/>
@@ -43,7 +43,7 @@ import TemplateGrid from 'src/components/grid/TemplateGrid';
 import { getProjects } from 'src/composables/Project';
 import { getTemplatesByType } from 'src/composables/TemplateManager';
 import ImportProjectDialog from 'components/dialog/ImportProjectDialog';
-import NewProjectTemplateDialog from 'components/dialog/NewProjectTemplateDialog';
+import CreateProjectTemplateDialog from 'components/dialog/CreateProjectTemplateDialog';
 import CreateProjectDialog from 'components/dialog/CreateProjectDialog';
 import DeleteProjectDialog from 'components/dialog/DeleteProjectDialog';
 import ProjectEvent from 'src/composables/events/ProjectEvent';
@@ -67,13 +67,13 @@ function setProjects() {
 }
 
 /**
- * Open NewProjectTemplate dialog.
+ * Open CreateProjectTemplate dialog.
  * @param {Object} template - Selected project template.
  */
-async function openNewProjectTemplateDialog(template) {
+async function openCreateProjectTemplateDialog(template) {
   DialogEvent.next({
     type: 'open',
-    key: 'NewProjectTemplate',
+    key: 'CreateProjectTemplate',
     template,
   });
 }

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -31,7 +31,7 @@
     </div>
     <import-project-dialog/>
     <new-project-template-dialog/>
-    <new-project-dialog/>
+    <create-project-dialog/>
     <delete-project-dialog/>
     <rename-project-dialog/>
   </q-page>
@@ -44,7 +44,7 @@ import { getProjects } from 'src/composables/Project';
 import { getTemplatesByType } from 'src/composables/TemplateManager';
 import ImportProjectDialog from 'components/dialog/ImportProjectDialog';
 import NewProjectTemplateDialog from 'components/dialog/NewProjectTemplateDialog';
-import NewProjectDialog from 'components/dialog/NewProjectDialog';
+import CreateProjectDialog from 'components/dialog/CreateProjectDialog';
 import DeleteProjectDialog from 'components/dialog/DeleteProjectDialog';
 import ProjectEvent from 'src/composables/events/ProjectEvent';
 import {

--- a/src/pages/ModelizerPage.vue
+++ b/src/pages/ModelizerPage.vue
@@ -1,7 +1,6 @@
 <template>
   <q-layout
     class="modelizer-page column"
-    data-cy="modelizer-page"
   >
     <modelizer-navigation-bar
       :projectName="projectName"

--- a/tests/unit/components/ModelizerModelsView.spec.js
+++ b/tests/unit/components/ModelizerModelsView.spec.js
@@ -102,11 +102,11 @@ describe('Test component: ModelizerModelsView', () => {
     });
   });
 
-  describe('Test function: openNewModelTemplateDialog', () => {
+  describe('Test function: openImportModelTemplateDialog', () => {
     it('should emit DialogEvent', async () => {
       DialogEvent.next = jest.fn();
 
-      await wrapper.vm.openNewModelTemplateDialog({});
+      await wrapper.vm.openImportModelTemplateDialog({});
 
       expect(DialogEvent.next).toBeCalledWith({
         type: 'open',

--- a/tests/unit/components/dialog/CreateProjectDialog.spec.js
+++ b/tests/unit/components/dialog/CreateProjectDialog.spec.js
@@ -1,7 +1,7 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
 import { shallowMount } from '@vue/test-utils';
 import { Notify } from 'quasar';
-import NewProjectDialog from 'src/components/dialog/NewProjectDialog.vue';
+import CreateProjectDialog from 'src/components/dialog/CreateProjectDialog.vue';
 import { useRouter } from 'vue-router';
 import DialogEvent from 'src/composables/events/DialogEvent';
 import { directive as viewer } from 'v-viewer';
@@ -27,7 +27,7 @@ jest.mock('src/composables/Project', () => ({
   initProject: jest.fn(),
 }));
 
-describe('Test component: NewProjectDialog', () => {
+describe('Test component: CreateProjectDialog', () => {
   let wrapper;
 
   const push = jest.fn();
@@ -37,7 +37,7 @@ describe('Test component: NewProjectDialog', () => {
   }));
 
   beforeEach(() => {
-    wrapper = shallowMount(NewProjectDialog, {
+    wrapper = shallowMount(CreateProjectDialog, {
       global: {
         directives: {
           viewer,
@@ -57,7 +57,7 @@ describe('Test component: NewProjectDialog', () => {
 
         await wrapper.vm.createProject('test');
 
-        expect(DialogEvent.next).toBeCalledWith({ type: 'close', key: 'NewProject' });
+        expect(DialogEvent.next).toBeCalledWith({ type: 'close', key: 'CreateProject' });
         expect(push).toBeCalledWith('/modelizer/test/models');
         expect(Notify.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'positive' }));
       });

--- a/tests/unit/components/dialog/CreateProjectTemplateDialog.spec.js
+++ b/tests/unit/components/dialog/CreateProjectTemplateDialog.spec.js
@@ -2,7 +2,7 @@ import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-j
 import { shallowMount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
 import i18nConfiguration from 'src/i18n';
-import NewProjectTemplateDialog from 'src/components/dialog/NewProjectTemplateDialog.vue';
+import CreateProjectTemplateDialog from 'src/components/dialog/CreateProjectTemplateDialog.vue';
 import { useRouter } from 'vue-router';
 import DialogEvent from 'src/composables/events/DialogEvent';
 import { directive as viewer } from 'v-viewer';
@@ -19,7 +19,7 @@ jest.mock('src/composables/events/DialogEvent', () => ({
   subscribe: jest.fn(),
 }));
 
-describe('Test component: NewProjectTemplateDialog', () => {
+describe('Test component: CreateProjectTemplateDialog', () => {
   let wrapper;
   let subscribe;
   let unsubscribe;
@@ -39,7 +39,7 @@ describe('Test component: NewProjectTemplateDialog', () => {
       return { unsubscribe };
     });
 
-    wrapper = shallowMount(NewProjectTemplateDialog, {
+    wrapper = shallowMount(CreateProjectTemplateDialog, {
       global: {
         plugins: [
           createI18n({ locale: 'en-US', messages: i18nConfiguration }),
@@ -68,7 +68,7 @@ describe('Test component: NewProjectTemplateDialog', () => {
 
         wrapper.vm.addProject('test');
 
-        expect(DialogEvent.next).toBeCalledWith({ type: 'close', key: 'NewProjectTemplate' });
+        expect(DialogEvent.next).toBeCalledWith({ type: 'close', key: 'CreateProjectTemplate' });
         expect(push).toBeCalledWith('/modelizer/test/models');
       });
     });
@@ -77,7 +77,7 @@ describe('Test component: NewProjectTemplateDialog', () => {
       it('should set projectTemplate value on valid event type', () => {
         expect(wrapper.vm.projectTemplate).toBeNull();
 
-        wrapper.vm.setProjectTemplate({ key: 'NewProjectTemplate', template: 'test' });
+        wrapper.vm.setProjectTemplate({ key: 'CreateProjectTemplate', template: 'test' });
         expect(wrapper.vm.projectTemplate).toEqual('test');
       });
 

--- a/tests/unit/components/form/CreateProjectForm.spec.js
+++ b/tests/unit/components/form/CreateProjectForm.spec.js
@@ -1,6 +1,6 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
 import { shallowMount } from '@vue/test-utils';
-import NewProjectForm from 'src/components/form/NewProjectForm.vue';
+import CreateProjectForm from 'src/components/form/CreateProjectForm.vue';
 
 installQuasarPlugin();
 
@@ -8,11 +8,11 @@ jest.mock('src/composables/Project', () => ({
   getProjects: jest.fn(() => ['project']),
 }));
 
-describe('Test component: NewProjectForm', () => {
+describe('Test component: CreateProjectForm', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallowMount(NewProjectForm, {});
+    wrapper = shallowMount(CreateProjectForm, {});
   });
 
   describe('Test function: onSubmit', () => {

--- a/tests/unit/components/form/CreateProjectTemplateForm.spec.js
+++ b/tests/unit/components/form/CreateProjectTemplateForm.spec.js
@@ -1,6 +1,6 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
 import { shallowMount } from '@vue/test-utils';
-import NewProjectTemplateForm from 'src/components/form/NewProjectTemplateForm.vue';
+import CreateProjectTemplateForm from 'src/components/form/CreateProjectTemplateForm.vue';
 import { Notify } from 'quasar';
 import Project from 'src/composables/Project';
 
@@ -29,11 +29,11 @@ jest.mock('src/composables/TemplateManager', () => ({
   getTemplateFileByPath: jest.fn(() => Promise.resolve()),
 }));
 
-describe('Test component: NewProjectTemplateForm', () => {
+describe('Test component: CreateProjectTemplateForm', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallowMount(NewProjectTemplateForm, {
+    wrapper = shallowMount(CreateProjectTemplateForm, {
       props: {
         template: {
           files: ['test.js'],

--- a/tests/unit/pages/HomePage.spec.js
+++ b/tests/unit/pages/HomePage.spec.js
@@ -55,17 +55,17 @@ describe('Test page component: HomePage', () => {
     });
   });
 
-  describe('Test function: openNewProjectTemplateDialog', () => {
+  describe('Test function: openCreateProjectTemplateDialog', () => {
     it('should emit DialogEvent', () => {
       DialogEvent.next = jest.fn();
 
       expect(DialogEvent.next).not.toHaveBeenCalled();
 
-      wrapper.vm.openNewProjectTemplateDialog({});
+      wrapper.vm.openCreateProjectTemplateDialog({});
 
       expect(DialogEvent.next).toHaveBeenCalledWith({
         type: 'open',
-        key: 'NewProjectTemplate',
+        key: 'CreateProjectTemplate',
         template: {},
       });
     });


### PR DESCRIPTION
- Updating and standardization `data-cy` for e2e tests
- Remove escape char & use single quote for data-cy
- Rename `NewProjectForm` and `NewProjectDialog` to `CreateProjectForm` and `CreateProjectDialog`
- Rename `NewProjectTemplateForm` and `NewProjectTemplateDialog` to `CreateProjectTemplateForm` and `CreateProjectTemplateDialog` 
- Use path instead of label in data-cy for files to avoid problem when multiple files have same name + update e2e tests
- Fix typos