### PR TITLE
Feature: Create component with drag and drop should keep mouse position

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Allowed to have a predefined list of values for Array attribute.
 * Text editor feature:
   * Integrate syntax colorization.
+* Modelization feature:
+  * Allow to use the mouse coordinates when placing new component on drag and drop feature.
 * Add new environment variable `KEEP_CYPRESS_ATTRIBUTE` to keep all cypress attribute in html.
 
 ### Changed

--- a/src/components/ModelizerDrawView.vue
+++ b/src/components/ModelizerDrawView.vue
@@ -53,6 +53,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { getTemplatesByType } from 'src/composables/TemplateManager';
 import ComponentDropOverlay from 'components/drawer/ComponentDropOverlay';
+import { ComponentDrawOption } from 'leto-modelizer-plugin-core';
 
 const route = useRoute();
 const query = computed(() => route.query);
@@ -143,6 +144,24 @@ async function initView() {
 }
 
 /**
+ * Get the coordinates to use for component draw options.
+ * @param {Object} event - Cursor event when dropping a new component.
+ * @param {Number} event.clientX - Position X of the cursor.
+ * @param {Number} event.clientY - Position Y of the cursor.
+ * @return {Object} The coordinates for new component.
+ */
+function getComponentPosition({ clientX, clientY }) {
+  const { __drawer: drawer } = data.plugin;
+  const { scale, translate } = drawer.actions.zoom;
+  const { left: rootX, top: rootY } = document.querySelector('#root').getBoundingClientRect();
+
+  return {
+    x: ((clientX - rootX) - translate.x) / scale,
+    y: ((clientY - rootY) - translate.y) / scale,
+  };
+}
+
+/**
  * Instantiate from a dragged component definition or template.
  * @param {DragEvent} event - The drag event.
  * @return {Promise<void>} Promise with nothing on success otherwise an error.
@@ -159,6 +178,7 @@ async function dropHandler(event) {
       data.plugin,
       `${defaultFolder.value}${route.query.path}`,
       componentDefinition,
+      new ComponentDrawOption({ ...getComponentPosition(event) }),
     );
     data.plugin.draw('root');
   } else {

--- a/src/composables/PluginManager.js
+++ b/src/composables/PluginManager.js
@@ -227,6 +227,7 @@ export async function initComponents(projectName, plugin, path) {
  * @param {Object} plugin - Plugin corresponding to the model.
  * @param {String} path - Model path (Plugin name & model name).
  * @param {Object} definition - Definition of the component.
+ * @param {ComponentDrawOption} [drawOption=null] - drawOption of the component.
  * @return {Promise<void>} Promise with nothing on success otherwise an error.
  */
 export async function addNewComponent(
@@ -234,8 +235,15 @@ export async function addNewComponent(
   plugin,
   path,
   definition,
+  drawOption = null,
 ) {
-  plugin.data.addComponent(definition, `${path}/`);
+  const componentId = plugin.data.addComponent(definition, `${path}/`);
+
+  if (drawOption) {
+    const component = plugin.data.getComponentById(componentId);
+    component.drawOption = drawOption;
+  }
+
   await renderModel(projectName, path, plugin);
 }
 

--- a/tests/manual/DragAndDrop.md
+++ b/tests/manual/DragAndDrop.md
@@ -1,0 +1,12 @@
+# Manual test: Check that the position of the component is equal to the position after drag and drop.
+
+Steps:
+
+1. Go to the homepage.
+2. Create project from scratch.
+3. Create model from scratch on `terrator-plugin`.
+4. Go to the draw page.
+6. Open the `terrator-plugin` components panel.
+7. Drag a component from the `terrator-plugin` components panel.
+8. Drop the component definition on the draw view.
+9. Check if the position of the component is equal to the mouse position on drop.

--- a/tests/unit/components/ModelizerDrawView.spec.js
+++ b/tests/unit/components/ModelizerDrawView.spec.js
@@ -113,6 +113,14 @@ describe('Test component: ModelizerDrawView', () => {
           ],
         },
       },
+      __drawer: {
+        actions: {
+          zoom: {
+            scale: 1,
+            translate: { x: 0, y: 0 },
+          },
+        },
+      },
       parse: pluginParse,
       draw: pluginDraw,
     };
@@ -189,6 +197,10 @@ describe('Test component: ModelizerDrawView', () => {
   });
 
   describe('Test function: dropHandler', () => {
+    const mockGetBoundingClientRect = jest.fn(() => ({ left: 0, top: 0 }));
+    const mockElement = { getBoundingClientRect: mockGetBoundingClientRect };
+    jest.spyOn(document, 'querySelector').mockReturnValue(mockElement);
+
     it('should call addNewComponent() when isTemplate is false', async () => {
       const event = {
         dataTransfer: {
@@ -201,6 +213,7 @@ describe('Test component: ModelizerDrawView', () => {
 
       await wrapper.vm.dropHandler(event);
 
+      expect(mockGetBoundingClientRect).toHaveBeenCalledTimes(1);
       expect(addNewComponent).toHaveBeenCalledTimes(1);
     });
 
@@ -216,6 +229,7 @@ describe('Test component: ModelizerDrawView', () => {
 
       await wrapper.vm.dropHandler(event);
 
+      expect(mockGetBoundingClientRect).toHaveBeenCalledTimes(1);
       expect(addNewTemplateComponent).toHaveBeenCalledTimes(1);
     });
 
@@ -233,6 +247,7 @@ describe('Test component: ModelizerDrawView', () => {
 
       await wrapper.vm.dropHandler(event);
 
+      expect(mockGetBoundingClientRect).toHaveBeenCalledTimes(1);
       expect(addNewTemplateComponent).toHaveBeenCalledTimes(1);
       expect(Notify.create).toHaveBeenCalledWith({
         message: 'errors.templates.getData',

--- a/tests/unit/composables/PluginManager.spec.js
+++ b/tests/unit/composables/PluginManager.spec.js
@@ -258,20 +258,44 @@ describe('Test composable: PluginManager', () => {
   });
 
   describe('Test function: addNewComponent', () => {
-    it('should call addComponent and render', async () => {
-      const plugin = {
+    let plugin;
+
+    beforeEach(() => {
+      plugin = {
         data: {
           addComponent: jest.fn(),
+          getComponentById: jest.fn(),
         },
         isParsable: () => true,
         render: jest.fn(() => []),
       };
 
+      plugin.data.getComponentById.mockReturnValue({ drawOption: null });
+    });
+
+    it('should call addComponent and render but not call getComponentById without position', async () => {
       expect(plugin.render).toHaveBeenCalledTimes(0);
 
       await PluginManager.addNewComponent('projectName', plugin, 'plugin/model', {});
 
       expect(plugin.data.addComponent).toHaveBeenCalledTimes(1);
+      expect(plugin.data.getComponentById).toHaveBeenCalledTimes(0);
+      expect(plugin.render).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call addComponent, getComponentById and render with position', async () => {
+      expect(plugin.render).toHaveBeenCalledTimes(0);
+
+      await PluginManager.addNewComponent(
+        'projectName',
+        plugin,
+        'plugin/model',
+        {},
+        { x: 0, y: 0 },
+      );
+
+      expect(plugin.data.addComponent).toHaveBeenCalledTimes(1);
+      expect(plugin.data.getComponentById).toHaveBeenCalledTimes(1);
       expect(plugin.render).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Add the function `getComponentPosition` in `ModelizerDrawView`  to set the position of the component when dropping it on modelizer viewport.

Resolve #225 