### PR TITLE
Fix model selection in TextView

### DIFF
--- a/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/add.component.feature
@@ -74,8 +74,8 @@ Feature: Test switch model to text view: add component/link
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'new_file.tf'
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'leto-modelizer.config.json'
 
-    When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_terrator-plugin/modelName/new_file.tf"]'
+    When I click on '[data-cy="file-tabs-container"] [data-cy="file_terrator-plugin/modelName/new_file.tf"]'
+    And  I wait 1 second
     Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
 
     When I set active file content to 'module "server" {}'

--- a/cypress/e2e/ModelizerPage/TextView/file/switch.model.file.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/switch.model.file.feature
@@ -1,0 +1,58 @@
+Feature: Test modelizer text view: switch model file
+
+  Background:
+    Given I clear cache
+    And   I set viewport size to '1536' px for width and '960' px for height
+    And   I set context field 'repository_url' with 'https://github.com/ditrit/leto-modelizer-project-test'
+    And   I set context field 'projectName' with 'leto-modelizer-project-test'
+    And   I set context field 'pluginName' with 'terrator-plugin'
+    And   I set context field 'modelName' with 'modelName'
+    And   I set context field 'model2Name' with 'model2Name'
+    And   I visit the '/'
+
+    When I click on '[data-cy="import-project-button"]'
+    And  I set on '[data-cy="import-project-form"] [data-cy="repository-input"]' text '{{ repository_url }}'
+    And  I set on '[data-cy="import-project-form"] [data-cy="username-input"]' text 'test'
+    And  I set on '[data-cy="import-project-form"] [data-cy="token-input"]' text 'test'
+    And  I click on '[data-cy="import-project-form"] [data-cy="submit-button"]'
+    Then I expect 'positive' toast to appear with text 'Project has been imported 🥳!'
+    And  I expect '[data-cy="import-project-form"]' is closed
+    And  I expect current url is '{{ projectName }}/models'
+    And  I expect '[data-cy="project-name"]' is '{{ projectName }}'
+
+    # Model creation
+    When I click on '[data-cy="create-model-button"]'
+    Then I expect '[data-cy="create-model-form"] [data-cy="plugin-select"]' is '{{ pluginName }}'
+
+    When I set on '[data-cy="create-model-form"] [data-cy="name-input"]' text '{{ modelName }}'
+    And  I click on '[data-cy="create-model-form"] [data-cy="submit-button"]'
+    Then I expect current url is '{{ projectName }}/modelizer/draw\?path={{ pluginName }}/{{ modelName }}'
+
+    When I click on '[data-cy="models-page-link-button"]'
+    Then I expect current url is '{{ projectName }}/models'
+
+    # Another model creation
+    When I click on '[data-cy="create-model-button"]'
+    Then I expect '[data-cy="create-model-form"] [data-cy="plugin-select"]' is '{{ pluginName }}'
+
+    When I set on '[data-cy="create-model-form"] [data-cy="name-input"]' text '{{ model2Name }}'
+    And  I click on '[data-cy="create-model-form"] [data-cy="submit-button"]'
+    Then I expect current url is '{{ projectName }}/modelizer/draw\?path={{ pluginName }}/{{ model2Name }}'
+
+    # Go to text view and check folders
+    When I click on '[data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect current url is '{{ projectName }}/modelizer/text\?path={{ pluginName }}/{{ model2Name }}'
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_{{ projectName }}"]' is '{{ projectName }}'
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_{{ pluginName }}"]' exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_{{ pluginName }}/{{ modelName }}"]' exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="folder_{{ pluginName }}/{{ model2Name }}"]' exists
+
+  Scenario: Select the file of another model should update url    
+    When I hover '[data-cy="file-explorer"] [data-cy="folder-button_{{ pluginName }}/{{ modelName }}"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="folder-button_{{ pluginName }}/{{ modelName }}"]'
+    And  I click on '[data-cy="file-explorer-action-menu"] [data-cy="create-file-action-item"]'
+    And  I set on '[data-cy="create-file-form"] [data-cy="name-input"]' text 'newFile'
+    And  I click on '[data-cy="create-file-form"] [data-cy="submit-button"]'
+    Then I expect 'positive' toast to appear with text 'File is created &#129395;!'
+    And  I expect '[data-cy="file-explorer"] [data-cy="file_{{ pluginName }}/{{ modelName }}/newFile"]' exists
+    And  I expect current url is '{{ projectName }}/modelizer/text\?path={{ pluginName }}/{{ modelName }}'

--- a/cypress/e2e/RoundTrips/rename.project.feature
+++ b/cypress/e2e/RoundTrips/rename.project.feature
@@ -69,6 +69,7 @@ Feature: Test roundtrip of the application : rename project
     And  I expect '[data-cy="file-explorer"] [data-cy="folder_terrator-plugin/{{modelName}}"]' exists
 
     # Check project name is displayed in home page
-    When I visit the '/'
-    Then I expect '[data-cy="project-card_renamedProject"]' appear 1 time on screen
+    When I click on '[data-cy="navigation-bar"] [data-cy="home-page-link"]'
+    Then I expect current url is '/'
+    And  I expect '[data-cy="project-card_renamedProject"]' appear 1 time on screen
     And  I expect '[data-cy="project-card_renamedProject"] [data-cy="title-container"]' is 'renamedProject'

--- a/tests/unit/components/ModelizerTextView.spec.js
+++ b/tests/unit/components/ModelizerTextView.spec.js
@@ -3,13 +3,49 @@ import { shallowMount } from '@vue/test-utils';
 import ModelizerTextView from 'src/components/ModelizerTextView.vue';
 import { createI18n } from 'vue-i18n';
 import i18nConfiguration from 'src/i18n';
+import FileEvent from 'src/composables/events/FileEvent';
+import { useRouter } from 'vue-router';
 
 installQuasarPlugin();
 
+jest.mock('src/composables/events/FileEvent', () => ({
+  SelectFileTabEvent: {
+    subscribe: jest.fn(),
+  },
+}));
+
+jest.mock('vue-router', () => ({
+  useRoute: () => ({ query: { path: 'pluginName/modelName' } }),
+  useRouter: jest.fn(),
+}));
+
+jest.mock('src/composables/Project', () => ({
+  getAllModels: () => [{
+    plugin: 'plugin',
+    name: 'name',
+  }],
+}));
+
 describe('Test component: ModelizerTextView', () => {
   let wrapper;
+  let selectFileTabEventSubscribe;
+  let selectFileTabEventUnsubscribe;
+  let useRouterPush;
 
   beforeEach(() => {
+    selectFileTabEventSubscribe = jest.fn();
+    selectFileTabEventUnsubscribe = jest.fn();
+    useRouterPush = jest.fn();
+
+    useRouter.mockImplementation(() => ({
+      push: useRouterPush,
+    }));
+
+    FileEvent.SelectFileTabEvent.subscribe.mockImplementation(() => {
+      selectFileTabEventSubscribe();
+      return { unsubscribe: selectFileTabEventUnsubscribe };
+    });
+
     wrapper = shallowMount(ModelizerTextView, {
       props: {
         projectName: 'project-00000000',
@@ -36,6 +72,89 @@ describe('Test component: ModelizerTextView', () => {
       it('should be false', () => {
         expect(wrapper.vm.showParsableFiles).toEqual(false);
       });
+    });
+  });
+
+  describe('Test function: getModel', () => {
+    it('should return model corresponding to the selected file', async () => {
+      process.env.MODELS_DEFAULT_FOLDER = '';
+      const model = await wrapper.vm.getModel('plugin/name/filename');
+
+      expect(model).toEqual({
+        plugin: 'plugin',
+        name: 'name',
+      });
+    });
+
+    it('should return undefined if MODELS_DEFAULT_FOLDER is defined', async () => {
+      process.env.MODELS_DEFAULT_FOLDER = 'test';
+      const model = await wrapper.vm.getModel('plugin/name/filename');
+
+      expect(model).toEqual(undefined);
+    });
+
+    it('should return undefined otherwise', async () => {
+      const model = await wrapper.vm.getModel(null);
+
+      expect(model).toEqual(undefined);
+    });
+  });
+
+  describe('Test function: onSelectFileTab', () => {
+    it('should only set selectedFileTabPath', async () => {
+      await wrapper.vm.onSelectFileTab('pluginName/modelName/fileName');
+
+      expect(useRouterPush).toHaveBeenCalledTimes(0);
+
+      await wrapper.vm.onSelectFileTab(null);
+
+      expect(useRouterPush).toHaveBeenCalledTimes(0);
+    });
+
+    it('should also call router.push()', async () => {
+      process.env.MODELS_DEFAULT_FOLDER = '';
+
+      await wrapper.vm.onSelectFileTab('notPlugin/fileName');
+
+      expect(useRouterPush).toHaveBeenCalledTimes(1);
+      expect(useRouterPush).toHaveBeenCalledWith({
+        name: 'modelizer',
+        params: {
+          viewType: 'text',
+          projectName: wrapper.vm.props.projectName,
+        },
+        query: {
+          path: 'pluginName/modelName',
+        },
+      });
+
+      await wrapper.vm.onSelectFileTab('plugin/name/fileName');
+
+      expect(useRouterPush).toHaveBeenCalledTimes(2);
+      expect(useRouterPush).toHaveBeenCalledWith({
+        name: 'modelizer',
+        params: {
+          viewType: 'text',
+          projectName: wrapper.vm.props.projectName,
+        },
+        query: {
+          path: 'plugin/name',
+        },
+      });
+    });
+  });
+
+  describe('Test hook function: onMounted', () => {
+    it('should subscribe to SelectFileTabEvent', () => {
+      expect(selectFileTabEventSubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Test hook function: onUnmounted', () => {
+    it('should unsubscribe to SelectFileTabEvent', () => {
+      expect(selectFileTabEventUnsubscribe).toHaveBeenCalledTimes(0);
+      wrapper.unmount();
+      expect(selectFileTabEventUnsubscribe).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Before the merge of #219, when we opened a file from another model in text view and returned to the drawing view, the tool automatically loaded the model associated with the opened file in the editor.

After the merge, the opening of the model associated with the file no longer occurs and we remain on the initially chosen model. This is the PR that fixes this regression.