### PR TITLE
Bugfix: Fix open parsable files

### DIFF
--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -297,7 +297,7 @@ function openModelFiles() {
       const plugin = getPluginByName(pluginName);
       const allPaths = localFileInformations.value
         .filter(({ path }) => path.startsWith(`${pluginName}/${modelName}/`))
-        .filter(({ path }) => plugin.isParsable({ path: path.split('/').pop() }))
+        .filter(({ path }) => plugin.isParsable({ path }))
         .map(({ path }) => path);
 
       allPaths.forEach((path) => {


### PR DESCRIPTION
All works with terraform plugin, but when we use another plugin like `githubator@0.1.1`. No files are open when we go to text editor.

This pull-request will fix this bug.