### PR TITLE
Bugfix: ComponentDetailPanel: boolean attributes with value `false` are removed by `ComponentDetailPanel.sanitizeAttributes`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix attribute error management.
 * Fix bug on nested object in attribute edition, see [this issue](https://github.com/ditrit/leto-modelizer/issues/203).
 * Fix bug on model files opening when switching on TextView, see [this issue](https://github.com/ditrit/leto-modelizer/issues/202).
+* Fix bug on loosing boolean attributes defined to `false`, see [this issue](https://github.com/ditrit/leto-modelizer/issues/261).
 
 ## [1.0.0] - 2023/02/16
 

--- a/src/components/drawer/ComponentDetailPanel.vue
+++ b/src/components/drawer/ComponentDetailPanel.vue
@@ -135,7 +135,7 @@ let pluginDefaultSubscription;
  */
 function sanitizeAttributes(attributes) {
   return attributes.reduce((acc, attribute) => {
-    if (attribute.value && attribute.value !== '') {
+    if (attribute.value !== undefined && attribute.value !== null && attribute.value !== '') {
       if (attribute.type !== 'Object') {
         acc.push(new ComponentAttribute(attribute));
       } else {

--- a/tests/unit/components/drawer/ComponentDetailPanel.spec.js
+++ b/tests/unit/components/drawer/ComponentDetailPanel.spec.js
@@ -98,6 +98,10 @@ describe('test component: Plugin Component Detail Panel', () => {
         name: 'attribute',
         value: 'value',
       }, {
+        name: 'attribute_false',
+        type: 'Boolean',
+        value: false,
+      }, {
         name: 'object_empty',
         type: 'Object',
         value: [],
@@ -113,6 +117,10 @@ describe('test component: Plugin Component Detail Panel', () => {
       expect(wrapper.vm.sanitizeAttributes(attributes)).toEqual([new ComponentAttribute({
         name: 'attribute',
         value: 'value',
+      }), new ComponentAttribute({
+        name: 'attribute_false',
+        type: 'Boolean',
+        value: false,
       }), new ComponentAttribute({
         name: 'object',
         type: 'Object',


### PR DESCRIPTION
Fix #261