### PR TITLE
Improvement: fix code smell

### DIFF
--- a/src/components/ModelizerDrawView.vue
+++ b/src/components/ModelizerDrawView.vue
@@ -203,10 +203,10 @@ async function dropHandler(event) {
   }
 }
 
-onMounted(() => {
-  initView();
+onMounted(async () => {
   pluginInitSubscription = PluginEvent.InitEvent.subscribe(initView);
   pluginDefaultSubscription = PluginEvent.DefaultEvent.subscribe(onDefaultEvent);
+  await initView();
 });
 
 onUnmounted(() => {

--- a/src/components/ModelizerDrawView.vue
+++ b/src/components/ModelizerDrawView.vue
@@ -109,7 +109,7 @@ async function onDefaultEvent({ event }) {
  * @return {Promise<void>} Promise with nothing on success otherwise an error.
  */
 async function initView() {
-  if (!query.value || !query.value.path) {
+  if (!query.value?.path) {
     return;
   }
 

--- a/src/components/ModelizerTextView.vue
+++ b/src/components/ModelizerTextView.vue
@@ -103,7 +103,7 @@ async function onSelectFileTab(event) {
     const model = await getModel(event);
     const modelPath = model ? `${model.plugin}/${model.name}` : query.value.path;
 
-    router.push({
+    await router.push({
       name: 'modelizer',
       params: {
         viewType: 'text',

--- a/src/components/ModelsView.vue
+++ b/src/components/ModelsView.vue
@@ -90,8 +90,8 @@ let updateModelSubscription;
  * Redirect to ModelizerDrawView corresponding to the given model.
  * @param {Object} model - Model to open.
  */
-function onModelCardClick(model) {
-  router.push({
+async function onModelCardClick(model) {
+  await router.push({
     name: 'modelizer',
     params: {
       viewType: 'draw',
@@ -123,14 +123,14 @@ async function openImportModelTemplateDialog(template) {
   });
 }
 
-watch(() => viewType.value, () => {
+watch(() => viewType.value, async () => {
   if (viewType.value === 'models') {
-    updateModels();
+    await updateModels();
   }
 });
 
 onMounted(async () => {
-  updateModels();
+  await updateModels();
   templates.value = await getTemplatesByType('model');
   updateModelSubscription = UpdateModelEvent.subscribe(updateModels);
 });

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -106,9 +106,9 @@ const buttonToggleOptions = computed(() => [{
   value: 'text',
   slot: 'content',
 }]);
-const isUploadButtonVisible = computed(() => !!project.value.git && !!project.value.git.repository);
-const isUploadButtonDisable = computed(() => !project.value.git || !project.value.git.username
-  || !project.value.git.token);
+const isUploadButtonVisible = computed(() => !!project.value.git?.repository);
+const isUploadButtonDisable = computed(() => !project.value.git?.username
+  || !project.value.git?.token);
 const uploadButtonTitle = computed(() => {
   if (isUploadButtonDisable.value) {
     return 'page.modelizer.header.button.upload.disable.title';

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -148,8 +148,8 @@ async function upload() {
  *
  * @param {string} newViewType - 'draw' or 'text'.
  */
-function onViewTypeUpdate(newViewType) {
-  router.push({
+async function onViewTypeUpdate(newViewType) {
+  await router.push({
     name: 'modelizer',
     params: {
       viewType: newViewType,

--- a/src/components/dialog/CreateProjectDialog.vue
+++ b/src/components/dialog/CreateProjectDialog.vue
@@ -40,12 +40,13 @@ async function createProject(projectId) {
 
   await initProject(project).then(() => {
     DialogEvent.next({ type: 'close', key: 'CreateProject' });
-    router.push(`/${projectId}/models`);
     Notify.create({
       type: 'positive',
       message: t('actions.home.createdProject'),
       html: true,
     });
+
+    return router.push(`/${projectId}/models`);
   }).catch(() => {
     Notify.create({
       type: 'warning',

--- a/src/components/dialog/CreateProjectTemplateDialog.vue
+++ b/src/components/dialog/CreateProjectTemplateDialog.vue
@@ -75,9 +75,9 @@ let dialogEventSubscription;
  * Close CreateProjectTemplate and redirect to project model page.
  * @param {String} projectId - Id of the new project.
  */
-function addProject(projectId) {
+async function addProject(projectId) {
   DialogEvent.next({ type: 'close', key: 'CreateProjectTemplate' });
-  router.push(`/${projectId}/models`);
+  await router.push(`/${projectId}/models`);
 }
 
 /**

--- a/src/components/dialog/ImportProjectDialog.vue
+++ b/src/components/dialog/ImportProjectDialog.vue
@@ -30,8 +30,8 @@ const router = useRouter();
  * Close importProjectDialog and redirect to project model page.
  * @param {String} projectId - Id of project.
  */
-function importProject(projectId) {
+async function importProject(projectId) {
   DialogEvent.next({ type: 'close', key: 'ImportProject' });
-  router.push(`/${projectId}/models`);
+  await router.push(`/${projectId}/models`);
 }
 </script>

--- a/src/components/drawer/ComponentDetailPanel.vue
+++ b/src/components/drawer/ComponentDetailPanel.vue
@@ -250,7 +250,7 @@ function reset() {
  * @param {Object} eventManager.event - The triggered event.
  */
 function setLocalValues({ event }) {
-  if (!event.components || !event.components[0]) {
+  if (!event.components?.[0]) {
     return;
   }
 

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -136,9 +136,9 @@ async function updateEditorContent() {
   editor.setValue(value);
 }
 
-onBeforeMount(() => {
+onBeforeMount(async () => {
   if (!editor) {
-    nextTick(createEditor);
+    await nextTick(createEditor);
   }
 });
 
@@ -149,8 +149,8 @@ onMounted(() => {
   updateFileContentSubscription = FileEvent.UpdateFileContentEvent.subscribe(updateEditorContent);
 });
 
-onUpdated(() => {
-  nextTick(updateEditorLayout);
+onUpdated(async () => {
+  await nextTick(updateEditorLayout);
 });
 
 onUnmounted(() => {

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -82,7 +82,7 @@ async function getFileContent() {
 function initMonacoLanguages(path) {
   const plugin = getPlugins().find((p) => p.isParsable({ path }));
 
-  if (plugin && plugin.configuration.editor.syntax !== null) {
+  if (plugin?.configuration.editor.syntax) {
     const { syntax } = plugin.configuration.editor;
 
     monaco.languages.register(syntax.languageSettings);

--- a/src/components/form/CreateModelForm.vue
+++ b/src/components/form/CreateModelForm.vue
@@ -86,7 +86,7 @@ async function onSubmit() {
         html: true,
       });
 
-      router.push({
+      return router.push({
         name: 'modelizer',
         params: {
           viewType: 'draw',

--- a/src/components/form/ImportModelTemplateForm.vue
+++ b/src/components/form/ImportModelTemplateForm.vue
@@ -93,7 +93,7 @@ async function onSubmit() {
         html: true,
       });
 
-      router.push({
+      return router.push({
         name: 'modelizer',
         params: {
           viewType: 'draw',

--- a/src/components/inputs/ObjectInput.vue
+++ b/src/components/inputs/ObjectInput.vue
@@ -89,8 +89,7 @@ const props = defineProps({
 });
 
 const expanded = ref(false);
-const hasError = computed(() => props.currentError !== null
-  && props.currentError.startsWith(`${props.fullName}.`));
+const hasError = computed(() => props.currentError?.startsWith(`${props.fullName}.`));
 
 /**
  * Get all sub-attributes of the provided attribute. Retrieve a list that contains instantiated

--- a/src/components/menu/GitBranchMenu.vue
+++ b/src/components/menu/GitBranchMenu.vue
@@ -231,10 +231,10 @@ async function setBranches() {
 /**
  * On open menu, call setBranches and close expand menu for both local and remote.
  */
-function onOpen() {
+async function onOpen() {
   showLocal.value = false;
   showRemote.value = false;
-  setBranches();
+  await setBranches();
 }
 
 /**


### PR DESCRIPTION
Fix sonar code smells:
- Prefer using an optional chain expression instead, as it's more concise and easier to read.
- Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler.

See `Reliability` and `Maintainability` sections on [sonar](https://sonarcloud.io/summary/new_code?id=ditrit_leto-modelizer)