### PR TITLE
Hide "About" page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Redesign project grid.
   * Redesign template grid.
   * Redesign template card.
+  * Remove "About" button.
 
 ## [1.1.0] - 2023/05/04
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -10,13 +10,6 @@
       class="bg-primary col"
     >
       <q-toolbar class="row justify-center footer">
-        <router-link
-          :to="{ name: 'About' }"
-          class="about-page-link text-white q-mr-md"
-        >
-          {{ $t('footer.about') }}
-        </router-link>
-        |
         <a
           :href="$sanitize(`https://github.com/ditrit/leto-modelizer/releases/tag/${version}`)"
           class="text-white q-ml-md"


### PR DESCRIPTION
[LET-132: Hide "About" page](https://ditrit.atlassian.net/browse/LET-132)

> The SG sponsor is not represented in the About page, and it needs a rework.
> We need to hide it before reworking it in [LET-149: Rework "About" page](https://ditrit.atlassian.net/browse/LET-149).