### PR TITLE
Bugfix: save component in valid file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix bug on models default folder opening, see [this issue](https://github.com/ditrit/leto-modelizer/issues/303).
 * Fix Sonar new bugs/code smell due to quality profil change, see [this issue](https://github.com/ditrit/leto-modelizer/issues/322).
+* Fix bug on using default file name from plugin instead of the file name specified by the user, when adding a component after creating a diagram from scratch.
 
 ### Removed
 

--- a/cypress/e2e/ModelizerPage/SwitchView/AddComponent.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/AddComponent.feature
@@ -14,7 +14,7 @@ Feature: Test switch model to text view: add component/link
     When I click on '[data-cy="create-model-button"]'
     Then I expect '[data-cy="create-model-form"] [data-cy="plugin-select"]' is 'terrator-plugin'
 
-    When I set on '[data-cy="create-model-form"] [data-cy="name-input"]' text 'infra/new_file.tf'
+    When I set on '[data-cy="create-model-form"] [data-cy="name-input"]' text 'infra/main.tf'
     And  I click on '[data-cy="create-model-form"] [data-cy="submit-button"]'
     Then I expect current url is 'projectName/modelizer/draw\?plugin=terrator-plugin&path=infra'
     And  I expect '[data-cy="component-definitions-item_terrator-plugin"]' appear 1 time on screen
@@ -31,7 +31,7 @@ Feature: Test switch model to text view: add component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file_new_file.tf"]' not exists
+    And  I expect '[data-cy="file_main.tf"]' not exists
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' not exists
 
   Scenario: Add a component (Draw view) should create project configuration file (Text view)
@@ -40,12 +40,12 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file_infra/new_file.tf"]' appear 2 time on screen
+    And  I expect '[data-cy="file_infra/main.tf"]' appear 2 time on screen
 
-    When I double click on '[data-cy="file_infra/new_file.tf"]'
+    When I double click on '[data-cy="file_infra/main.tf"]'
     And  I wait 1 second
-    Then I expect '[data-cy="file_infra/new_file.tf"]' appear 2 times on screen
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    Then I expect '[data-cy="file_infra/main.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'provider.*"aws".*{}'
 
   Scenario: Update plugin file content with a new object (Text view) should display the corresponding plugin component (Draw view)
@@ -54,15 +54,15 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file_infra/new_file.tf"]' appear 2 times on screen
+    And  I expect '[data-cy="file_infra/main.tf"]' appear 2 times on screen
 
-    When I double click on '[data-cy="file_infra/new_file.tf"]'
+    When I double click on '[data-cy="file_infra/main.tf"]'
     And  I wait 1 second
-    Then I expect '[data-cy="file_infra/new_file.tf"]' appear 2 times on screen
+    Then I expect '[data-cy="file_infra/main.tf"]' appear 2 times on screen
 
-    When I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
+    When I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
     And  I wait 1 second
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
 
     When I set active file content to 'module "server" {}'
     And  I wait 1 second
@@ -85,12 +85,12 @@ Feature: Test switch model to text view: add component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file_infra/new_file.tf"]' appear 2 time on screen
+    And  I expect '[data-cy="file_infra/main.tf"]' appear 2 time on screen
     And  I expect '[data-cy="file_leto-modelizer.config.json"]' appear 1 time on screen
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
     And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 
@@ -101,11 +101,11 @@ Feature: Test switch model to text view: add component/link
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file_infra/new_file.tf"]' appear 2 time on screen
+    And  I expect '[data-cy="file_infra/main.tf"]' appear 2 time on screen
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{}'
     And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
     But  I expect active file content to not contain 'gateway_id.*=.*\["aws_internet_gateway_1"\]'

--- a/cypress/e2e/ModelizerPage/SwitchView/Delete.feature
+++ b/cypress/e2e/ModelizerPage/SwitchView/Delete.feature
@@ -33,10 +33,10 @@ Feature: Test switch model to text view: delete component/link
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    And  I expect '[data-cy="file-explorer"] [data-cy="file_infra/new_file.tf"]' exists
+    And  I expect '[data-cy="file-explorer"] [data-cy="file_infra/main.tf"]' exists
 
-    When I double click on '[data-cy="file-explorer"] [data-cy="file_infra/new_file.tf"]'
-    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    When I double click on '[data-cy="file-explorer"] [data-cy="file_infra/main.tf"]'
+    And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'provider.*"aws".*{}'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Draw'
@@ -47,7 +47,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
-    But  I expect '[data-cy="file_new_file.tf"]' not exists
+    But  I expect '[data-cy="file_main.tf"]' not exists
 
   Scenario: Delete one of two components (Draw view) should remove corresponding object inside plugin file content (Text view)
     When I click on '[data-cy="component-definition_aws"]'
@@ -61,8 +61,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'provider.*"aws".*{}'
     And  I expect active file content to contain 'provider.*"server".*{}'
 
@@ -80,21 +80,21 @@ Feature: Test switch model to text view: delete component/link
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
-    When I double click on '[data-cy="file_infra/new_file.tf"]'
+    When I double click on '[data-cy="file_infra/main.tf"]'
     And  I wait 1 second
     Then I expect active file content to contain 'module.*"server".*{}'
     But  I expect active file content to not contain 'provider.*"aws".*{}'
 
   Scenario: Remove object inside plugin file content (Text view) should remove related component (Draw view)
-    #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - new_file.tf)
+    #  NOTE: NOT WORKING if plugin file content is empty (error console -> TypeError: JSON.parse(...) is null - main.tf)
     When I click on '[data-cy="component-definition_aws"]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
 
     When I set active file content to '[]'
     And  I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
@@ -110,8 +110,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
 
     When I set active file content to 'provider "aws" {}'
     And  I wait 1 second
@@ -128,11 +128,11 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
 
-    When I hover '[data-cy="file-explorer"] [data-cy="file-button_infra/new_file.tf"]' to make it visible
-    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_infra/new_file.tf"]'
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_infra/main.tf"]' to make it visible
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_infra/main.tf"]'
     Then I expect '[data-cy="file-explorer-action-menu"]' exists
 
     When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
@@ -142,7 +142,7 @@ Feature: Test switch model to text view: delete component/link
     And  I wait 1 second
     Then I expect 'positive' toast to appear with text 'File is deleted.'
     And  I expect '[data-cy="delete-file-form"]' is closed
-    And  I expect '[data-cy="file_infra/new_file.tf"]' not exists
+    And  I expect '[data-cy="file_infra/main.tf"]' not exists
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
@@ -164,8 +164,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
     And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 
@@ -181,7 +181,7 @@ Feature: Test switch model to text view: delete component/link
 
     When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
     And  I wait 1 second
-    And  I double click on '[data-cy="file_infra/new_file.tf"]'
+    And  I double click on '[data-cy="file_infra/main.tf"]'
     And  I wait 1 second
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
     And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{}'
@@ -203,8 +203,8 @@ Feature: Test switch model to text view: delete component/link
     Then I expect '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="true"] [class="block"]' is 'Text'
 
     When I wait 1 second
-    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/new_file.tf"]'
-    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I click on '[data-cy="file-tabs-container"] [data-cy="file_infra/main.tf"]'
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
     And  I expect active file content to contain 'resource.*"aws_subnet".*"aws_subnet_1".*{.*gateway_id.*=.*\["aws_internet_gateway_1"\]}'
     And  I expect active file content to contain 'resource.*"aws_internet_gateway".*"aws_internet_gateway_1".*{}'
 

--- a/cypress/e2e/ModelizerPage/TextView/file/DeleteFile.feature
+++ b/cypress/e2e/ModelizerPage/TextView/file/DeleteFile.feature
@@ -335,3 +335,39 @@ Feature: Test modelizer text view: delete file and folder
     And  I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'README.md'
     And  I expect '[data-cy="file-tabs-container"] [data-cy="inactive-tab"]' is 'main.tf'
     And  I expect '[data-cy="folder_terraform/folder"]' not exists
+
+  Scenario: Save the component in defaultFileName when diagram doesn't have any file
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'main.tf'
+
+    # Delete main.tf
+    When I hover '[data-cy="file-explorer"] [data-cy="file-button_infra/main.tf"]' to make it visible
+    And  I wait 1 second
+    And  I click on '[data-cy="file-explorer"] [data-cy="file-button_infra/main.tf"]'
+    Then I expect '[data-cy="file-explorer-action-menu"]' exists
+
+    When I click on '[data-cy="file-explorer-action-menu"] [data-cy="delete-file-action-item"]'
+    Then I expect '[data-cy="delete-file-dialog"]' exists
+
+    When I click on '[data-cy="delete-file-form"] [data-cy="submit-button"]'
+    Then I expect 'positive' toast to appear with text 'File is deleted.'
+    And  I expect '[data-cy="delete-file-form"]' is closed
+    And  I expect '[data-cy="file_infra/main.tf"]' not exists
+    And  I expect current url is '{{ projectName }}/modelizer/text\?plugin=terrator-plugin&path=infra'
+
+    # Go back to the draw view
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    Then I expect current url is '{{ projectName }}/modelizer/draw\?plugin=terrator-plugin&path=infra'
+
+    # Add component
+    When I click on '[data-cy="component-definitions-item_terrator-plugin"]'
+    Then I expect '[data-cy="component-definition_aws"]' exists
+
+    When I click on '[data-cy="component-definition_aws"]'
+    Then I expect '[data-cy="draw-container"] [id^="aws"]' exists
+
+    # Go back to the text view
+    When I click on '[data-cy="navigation-bar"] [data-cy="modelizer-switch-button"] [aria-pressed="false"]'
+    And  I wait 2 seconds
+    Then I expect '[data-cy="file-tabs-container"] [data-cy="active-tab"]' is 'new_file.tf'
+    And  I expect '[data-cy="file_infra/new_file.tf"]' exists
+    And  I expect active file content to contain 'provider.*"aws".*{}'

--- a/src/components/card/ComponentDefinitionCard.vue
+++ b/src/components/card/ComponentDefinitionCard.vue
@@ -59,6 +59,7 @@ import {
 } from 'src/composables/PluginManager';
 import { useRoute } from 'vue-router';
 import DefinitionMenu from 'components/menu/DefinitionMenu.vue';
+import { getModelFiles } from 'src/composables/Project';
 
 const route = useRoute();
 const props = defineProps({
@@ -117,10 +118,16 @@ const componentIcon = computed(() => {
  */
 async function onClickItem() {
   if (!props.definition.isTemplate) {
+    let path = (await getModelFiles(projectName.value, query.value.path, plugin.value))[0]?.path;
+
+    if (!path) {
+      path = `${query.value.path}/${plugin.value.configuration.defaultFileName}`;
+    }
+
     await addNewComponent(
       projectName.value,
       plugin.value,
-      query.value.path,
+      path,
       props.definition,
     );
   } else {

--- a/src/composables/Project.js
+++ b/src/composables/Project.js
@@ -827,6 +827,10 @@ export async function getAllModels(projectId) {
  * @return {Promise<Array<FileInput>>} Promise with FileInputs array on success otherwise an error.
  */
 export async function getModelFiles(projectName, modelPath, plugin) {
+  if (!await isDirectory(`${projectName}/${modelPath}`)) {
+    return getFileInputs(plugin, [new FileInformation({ path: modelPath })], projectName);
+  }
+
   const files = await readDir(`${projectName}/${modelPath}`);
   const fileInformations = files.map((file) => new FileInformation({ path: `${modelPath}/${file}` }));
 

--- a/tests/unit/composables/Project.spec.js
+++ b/tests/unit/composables/Project.spec.js
@@ -160,6 +160,12 @@ jest.mock('browserfs', () => ({
   })),
 }));
 
+jest.mock('src/composables/PluginManager', () => ({
+  getFileInputs: () => [],
+  getPlugins: () => [],
+  getPluginTags: () => [],
+}));
+
 describe('Test composable: Project', () => {
   let gitAddMock;
   let gitAddRemoteMock;


### PR DESCRIPTION
When creating a diagram from scratch then adding a component via the draw view, the component is saved in the default plugin file instead of the file specified during creation.

This pr should fix this bug.