### PR TITLE
Fix missing property for adminUrl in quasar config

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -113,7 +113,7 @@ module.exports = configure((ctx) => ({
         ? Object.prototype.hasOwnProperty.call(configuration?.backend, 'url')
           && Object.prototype.hasOwnProperty.call(configuration?.backend, 'appId')
         : false,
-      ADMIN_URL: configuration?.adminUrl || null,
+      ADMIN_URL: configuration?.backend?.adminUrl || null,
       BACKEND_APP_ID: configuration?.backend?.appId,
     },
     // extractCSS: false,


### PR DESCRIPTION
Fix missing property for adminUrl in quasar config.