### PR TITLE
Add debounce on editing attribute name to avoid losing focus

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [Unreleased]
+
+### Fixed
+
+* Losing focus on editing new attribute name when modify component details. 
+
 ## [1.4.0] - 2024/10/15
 
 ### Added

--- a/src/components/inputs/InputWrapper.vue
+++ b/src/components/inputs/InputWrapper.vue
@@ -7,6 +7,7 @@
         v-model="name"
         :label="$t('plugin.component.attribute.name')"
         class="col-4 q-px-md"
+        debounce="1000"
         @update:model-value="(event) => emit('update:attribute-name', {
           attributeName: attribute.name,
           newName: event,


### PR DESCRIPTION
To reproduce the bug before this branch, you have to click on component and add a new attribute, when you type the new attribute name, you will lost focus on each letter type. This PR fix this.